### PR TITLE
feat: add OCR subtitle encoder for bitmap-to-text conversion

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -61,6 +61,97 @@ out.webp#xywh=160,0,160,90
 
 00:00:10.000 --> 00:00:15.000
 out.webp#xywh=320,0,160,90
+
+---
+
+### v1.0.31 - April 13, 2026
+
+#### 🔤 Added OCR Subtitle Encoder
+
+**New Feature: Bitmap-to-Text Subtitle Conversion via Tesseract OCR**
+
+Added a custom `ocr_subtitle` encoder that converts bitmap subtitles (DVD/Blu-ray) to text subtitles (WebVTT, SRT) entirely within FFmpeg, eliminating the need for external OCR processing pipelines.
+
+#### What's New
+- **OCR Subtitle Encoder**: Converts `dvd_subtitle` and `hdmv_pgs_subtitle` bitmap streams to text using Tesseract OCR
+- **Luminance-Weighted Conversion**: Smart grayscale preprocessing that separates bright text from dark outlines for optimal OCR accuracy
+- **3x Upscaling**: Nearest-neighbor upscale before OCR for better character and line detection (configurable via `-ocr_scale`)
+- **Music Note Fixups**: Optional post-processing (`-ocr_fixups 1`) that corrects common Tesseract misreads of ♪ symbols
+- **Language Support**: Auto-detects language from input stream metadata, falls back to English, overridable via `-ocr_language`
+- **Cross-Platform**: Available on all supported platforms (Linux x86_64/aarch64, Windows x86_64, macOS x86_64/ARM64)
+
+#### Technical Details
+- Encoder implementation: `libavcodec/ocr_subtitle_enc.c`
+- Build script: `scripts/52-ocr-subtitle-encoder.sh`
+- Codec ID: `AV_CODEC_ID_WEBVTT` (compatible with WebVTT and SRT muxers)
+- Dependency: libtesseract (already in build via `--enable-libtesseract`)
+- Patched `ffmpeg_mux_init.c` to allow bitmap→text subtitle transcoding
+
+#### Use Case
+This feature enables the NoMercy MediaServer to:
+- Convert DVD/Blu-ray bitmap subtitles to searchable text formats
+- Replace the fragile C# OCR parsing pipeline with a single FFmpeg command
+- Support any Tesseract language for international subtitle conversion
+- Produce WebVTT files directly consumable by the web video player
+
+#### Usage Example
+```bash
+# DVD subtitle → WebVTT (explicit encoder)
+ffmpeg -i movie.mkv -map 0:s:0 -c:s ocr_subtitle output.vtt
+
+# With French language
+ffmpeg -i movie.mkv -map 0:s:0 -c:s ocr_subtitle -ocr_language fra output.vtt
+
+# With music note fixups enabled
+ffmpeg -i movie.mkv -map 0:s:0 -c:s ocr_subtitle -ocr_fixups 1 output.vtt
+
+# Custom tessdata path and scale factor
+ffmpeg -i movie.mkv -map 0:s:0 -c:s ocr_subtitle -datapath /path/to/tessdata -ocr_scale 4 output.vtt
+```
+
+#### Encoder Options
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `ocr_language` | string | `eng` | Tesseract OCR language |
+| `datapath` | string | *(env)* | Path to tessdata directory (falls back to `TESSDATA_PREFIX`) |
+| `ocr_fixups` | bool | `false` | Fix common OCR misreads (♪ music notes) |
+| `ocr_scale` | int | `3` | Upscale factor for bitmap before OCR (1-8) |
+
+---
+
+### v1.0.30 - April 12, 2026
+
+#### 📀 Added VOBsub Muxer
+
+**New Feature: DVD Subtitle Extraction to .sub + .idx Pairs**
+
+Added a custom VOBsub muxer that enables FFmpeg to write proper VobSub (.sub + .idx) file pairs when extracting DVD bitmap subtitles, preserving the original bitmap data without re-encoding.
+
+#### What's New
+- **VOBsub Muxer**: Writes MPEG-2 PS packets to `.sub` and a VobSub v7 text index to `.idx`
+- **Palette Preservation**: Extracts and writes the DVD subtitle color palette to the index file
+- **Language Support**: Carries language metadata from the source stream to the index file
+- **Normalized Timestamps**: Proper timestamp handling for accurate subtitle timing
+- **Cross-Platform**: Available on all supported platforms (Linux x86_64/aarch64, Windows x86_64, macOS x86_64/ARM64)
+
+#### Technical Details
+- Muxer implementation: `libavformat/vobsubenc.c`
+- Build script: `scripts/51-vobsub-muxer.sh`
+- Output: paired `.idx` (text index) + `.sub` (MPEG-2 PS bitmap data)
+- Copy codec support: no re-encoding needed, preserves original bitmap data
+
+#### Use Case
+This feature enables the NoMercy MediaServer to:
+- Extract DVD subtitle streams as standalone VobSub files
+- Preserve original bitmap subtitle quality without transcoding
+- Support downstream OCR or subtitle editing workflows
+- Maintain compatibility with media players that expect VobSub format
+
+#### Usage Example
+```bash
+# Extract DVD subtitles to VobSub pair
+ffmpeg -i movie.mkv -map 0:s:0 -c:s copy output.idx
+# produces output.idx (text index) + output.sub (bitmap data)
 ```
 
 ---

--- a/scripts/52-ocr-subtitle-encoder.sh
+++ b/scripts/52-ocr-subtitle-encoder.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# OCR Subtitle Encoder — converts bitmap subtitles to text using Tesseract OCR
+# Registers ff_ocr_subtitle_encoder in libavcodec with AV_CODEC_ID_WEBVTT
+
+# Copy the encoder source to FFmpeg
+cp /scripts/includes/ocr_subtitle_enc.c /build/ffmpeg/libavcodec/ocr_subtitle_enc.c
+
+# 1. Register the encoder extern declaration in allcodecs.c
+log "Step 1: Adding extern declaration to allcodecs.c"
+
+if ! grep -q "ff_ocr_subtitle_encoder" /build/ffmpeg/libavcodec/allcodecs.c; then
+    sed -i '0,/^extern const FFCodec ff_movtext_encoder;$/s//&\nextern const FFCodec ff_ocr_subtitle_encoder;/' /build/ffmpeg/libavcodec/allcodecs.c
+    log "  Added extern declaration"
+else
+    log "  Extern declaration already exists"
+fi
+
+if grep -q "ff_ocr_subtitle_encoder" /build/ffmpeg/libavcodec/allcodecs.c; then
+    log "  Verified in allcodecs.c"
+else
+    log "  ERROR: allcodecs.c verification failed!"
+    exit 1
+fi
+
+# 2. Add the encoder object to the Makefile
+log "Step 2: Adding to Makefile"
+
+if ! grep -q "ocr_subtitle_enc.o" /build/ffmpeg/libavcodec/Makefile; then
+    sed -i '/^OBJS-\$(CONFIG_TEXT_ENCODER)/a\
+OBJS-$(CONFIG_OCR_SUBTITLE_ENCODER)          += ocr_subtitle_enc.o' /build/ffmpeg/libavcodec/Makefile
+    log "  Added to Makefile"
+else
+    log "  Makefile entry already exists"
+fi
+
+if grep -q "ocr_subtitle_enc.o" /build/ffmpeg/libavcodec/Makefile; then
+    log "  Verified in Makefile"
+else
+    log "  ERROR: Makefile verification failed!"
+    exit 1
+fi
+
+# 3. Declare libtesseract dependency in configure
+#    Insert next to the existing ocr_filter_deps (also libtesseract)
+log "Step 3: Adding encoder dependency to configure"
+
+if ! grep -q "ocr_subtitle_encoder_deps" /build/ffmpeg/configure; then
+    sed -i '/^ocr_filter_deps=/a ocr_subtitle_encoder_deps="libtesseract"' /build/ffmpeg/configure
+    log "  Added encoder dependency"
+else
+    log "  Encoder dependency already exists"
+fi
+
+if grep -q "ocr_subtitle_encoder_deps" /build/ffmpeg/configure; then
+    log "  Verified in configure"
+else
+    log "  ERROR: configure verification failed!"
+    exit 1
+fi
+
+# 4. Patch fftools to allow bitmap→text subtitle transcoding for ocr_subtitle
+#    FFmpeg blocks cross-type subtitle encoding (bitmap↔text) in ffmpeg_mux_init.c.
+#    We relax the check: skip the error when the encoder is ocr_subtitle.
+log "Step 4: Patching ffmpeg_mux_init.c for bitmap-to-text transcoding"
+
+if ! grep -q "ocr_subtitle" /build/ffmpeg/fftools/ffmpeg_mux_init.c; then
+    sed -i 's/input_props != output_props) {/input_props != output_props \&\&\n            (!subtitle_enc->codec || strcmp(subtitle_enc->codec->name, "ocr_subtitle"))) {/' /build/ffmpeg/fftools/ffmpeg_mux_init.c
+    log "  Patched bitmap-to-text check"
+else
+    log "  Patch already applied"
+fi
+
+if grep -q "ocr_subtitle" /build/ffmpeg/fftools/ffmpeg_mux_init.c; then
+    log "  Verified in ffmpeg_mux_init.c"
+else
+    log "  ERROR: ffmpeg_mux_init.c verification failed!"
+    exit 1
+fi
+
+# 5. Auto-detect OCR language from input stream metadata
+#    When the user doesn't specify -ocr_language, read the language tag from
+#    the input subtitle stream and pass it to the encoder before init.
+#    Priority: user -ocr_language > stream metadata > "eng" fallback (in encoder init)
+log "Step 5: Patching language auto-detection from stream metadata"
+
+if ! grep -q "ocr_language" /build/ffmpeg/fftools/ffmpeg_mux_init.c; then
+    cat > /tmp/ocr_lang_patch.c << 'LANGPATCH'
+
+        /* Auto-detect OCR language from input stream metadata */
+        if (subtitle_enc->codec &&
+            !strcmp(subtitle_enc->codec->name, "ocr_subtitle")) {
+            uint8_t *lang = NULL;
+            av_opt_get(subtitle_enc, "ocr_language", AV_OPT_SEARCH_CHILDREN, &lang);
+            if (!lang || !lang[0]) {
+                AVDictionaryEntry *e = av_dict_get(ost->ist->st->metadata, "language", NULL, 0);
+                if (e && e->value[0])
+                    av_opt_set(subtitle_enc, "ocr_language", e->value, AV_OPT_SEARCH_CHILDREN);
+            }
+            av_free(lang);
+        }
+LANGPATCH
+
+    # Insert after the closing brace of the bitmap-text check (first } after "bitmap to bitmap")
+    awk '
+    /or bitmap to bitmap/ { found=1 }
+    found && /^        \}/ {
+        print
+        while ((getline line < "/tmp/ocr_lang_patch.c") > 0) print line
+        found=0
+        next
+    }
+    { print }' /build/ffmpeg/fftools/ffmpeg_mux_init.c > /tmp/mux_init_patched.c \
+        && mv /tmp/mux_init_patched.c /build/ffmpeg/fftools/ffmpeg_mux_init.c
+
+    rm -f /tmp/ocr_lang_patch.c
+    log "  Patched language auto-detection"
+else
+    log "  Language patch already applied"
+fi
+
+if grep -q "ocr_language" /build/ffmpeg/fftools/ffmpeg_mux_init.c; then
+    log "  Verified language detection in ffmpeg_mux_init.c"
+else
+    log "  ERROR: language detection verification failed!"
+    exit 1
+fi
+
+exit 0

--- a/scripts/includes/ocr_subtitle_enc.c
+++ b/scripts/includes/ocr_subtitle_enc.c
@@ -1,0 +1,328 @@
+/*
+ * OCR subtitle encoder using Tesseract
+ * Converts bitmap subtitles (DVD/Blu-ray) to text for WebVTT/SRT output
+ *
+ * Copyright (c) 2026 NoMercy Entertainment
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "avcodec.h"
+#include "codec_internal.h"
+#include "libavutil/mem.h"
+#include "libavutil/opt.h"
+
+#include <tesseract/capi.h>
+
+typedef struct OCRSubtitleContext {
+    AVClass *class;
+    TessBaseAPI *tess;
+    char *language;
+    char *datapath;
+    int fixups;
+    int scale;
+} OCRSubtitleContext;
+
+static av_cold int ocr_subtitle_init(AVCodecContext *avctx)
+{
+    OCRSubtitleContext *ctx = avctx->priv_data;
+    const char *lang = ctx->language && ctx->language[0] ? ctx->language : "eng";
+
+    ctx->tess = TessBaseAPICreate();
+    if (!ctx->tess) {
+        av_log(avctx, AV_LOG_ERROR, "Failed to create Tesseract instance\n");
+        return AVERROR(ENOMEM);
+    }
+
+    if (TessBaseAPIInit3(ctx->tess, ctx->datapath, lang) == -1) {
+        av_log(avctx, AV_LOG_ERROR,
+               "Tesseract init failed for language '%s'. "
+               "Ensure '%s.traineddata' exists in the path specified by "
+               "TESSDATA_PREFIX or -datapath.\n",
+               lang, lang);
+        TessBaseAPIDelete(ctx->tess);
+        ctx->tess = NULL;
+        return AVERROR_EXTERNAL;
+    }
+
+    TessBaseAPISetPageSegMode(ctx->tess, PSM_SINGLE_BLOCK);
+
+    av_log(avctx, AV_LOG_INFO,
+           "OCR subtitle encoder initialized (language: %s)\n", lang);
+
+    return 0;
+}
+
+/**
+ * Convert a palette-indexed bitmap to grayscale for Tesseract OCR.
+ *
+ * DVD/PGS subtitles typically have bright text (white/yellow) with a dark
+ * outline on a transparent background. Using luminance weighted by alpha
+ * composites against black and then inverts, which:
+ *   - bright opaque text  → dark (Tesseract foreground)
+ *   - dark opaque outline → light (merges with background)
+ *   - transparent bg      → white (Tesseract background)
+ *
+ * Palette layout on little-endian (uint32_t 0xAARRGGBB):
+ *   byte[0]=B, byte[1]=G, byte[2]=R, byte[3]=A
+ */
+static void bitmap_to_grayscale(const uint8_t *palette, const uint8_t *src,
+                                uint8_t *dst, int w, int h, int linesize,
+                                int scale)
+{
+    int ow = w * scale;
+
+    for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+            uint8_t idx = src[y * linesize + x];
+            uint8_t b = palette[idx * 4];
+            uint8_t g = palette[idx * 4 + 1];
+            uint8_t r = palette[idx * 4 + 2];
+            uint8_t a = palette[idx * 4 + 3];
+            int lum  = (54 * r + 183 * g + 19 * b) >> 8;
+            uint8_t val = 255 - (uint8_t)((lum * a + 127) / 255);
+
+            for (int sy = 0; sy < scale; sy++)
+                for (int sx = 0; sx < scale; sx++)
+                    dst[(y * scale + sy) * ow + x * scale + sx] = val;
+        }
+    }
+}
+
+/**
+ * Run Tesseract OCR on a single bitmap subtitle rect.
+ *
+ * Returns 0 on success. On success, *out_text is set to the OCR result
+ * (caller must free with TessDeleteText) or NULL if no text was recognized.
+ */
+static int ocr_bitmap_rect(AVCodecContext *avctx, const AVSubtitleRect *rect,
+                           char **out_text)
+{
+    OCRSubtitleContext *ctx = avctx->priv_data;
+    int scale = ctx->scale;
+    int sw = rect->w * scale;
+    int sh = rect->h * scale;
+    uint8_t *gray;
+    char *text;
+
+    *out_text = NULL;
+
+    if (rect->w <= 0 || rect->h <= 0 || !rect->data[0] || !rect->data[1])
+        return 0;
+
+    gray = av_malloc(sw * sh);
+    if (!gray)
+        return AVERROR(ENOMEM);
+
+    bitmap_to_grayscale(rect->data[1], rect->data[0], gray,
+                        rect->w, rect->h, rect->linesize[0], scale);
+
+    text = TessBaseAPIRect(ctx->tess, gray, 1, sw, 0, 0, sw, sh);
+    av_free(gray);
+
+    if (!text || !text[0]) {
+        if (text)
+            TessDeleteText(text);
+        return 0;
+    }
+
+    *out_text = text;
+    return 0;
+}
+
+static int trim_trailing(const char *text, int len)
+{
+    while (len > 0 && (text[len - 1] == '\n' || text[len - 1] == '\r' ||
+                       text[len - 1] == ' '  || text[len - 1] == '\t'))
+        len--;
+    return len;
+}
+
+/**
+ * Fix common Tesseract misreads of the ♪ music note symbol.
+ *
+ * Tesseract reads ♪ as J, &, I, or ' at the start of lines.
+ * Patterns matched (per line):
+ *   [&JI'][&JI'] (?=[A-Z])  →  ♪   (double misread)
+ *   [&JI'] (?=[A-Z])        →  ♪   (single misread)
+ * Preserves optional "- " dialog prefix.
+ *
+ * Operates in-place on buf[0..len-1]. Returns new length.
+ */
+static int fix_music_notes(uint8_t *buf, int len, int bufsize)
+{
+    static const uint8_t note_utf8[] = {0xE2, 0x99, 0xAA}; /* ♪ U+266A */
+    uint8_t *tmp;
+    int src = 0, dst = 0;
+    int at_line_start = 1;
+
+    if (len <= 0)
+        return len;
+
+    tmp = av_malloc(bufsize);
+    if (!tmp)
+        return len;
+
+    while (src < len && dst < bufsize - 4) {
+        if (at_line_start) {
+            int s = src;
+
+            /* skip optional "- " dialog prefix */
+            if (s < len - 1 && buf[s] == '-' && buf[s + 1] == ' ') {
+                tmp[dst++] = buf[s++];
+                tmp[dst++] = buf[s++];
+            } else if (s < len - 2 && buf[s] == '-' && buf[s + 1] != ' ') {
+                /* "- " with no space variant: "-X" — not a dialog prefix */
+            }
+
+            /* check for misread music note: one or two chars from [&JI'] */
+            if (s < len - 1 &&
+                (buf[s] == '&' || buf[s] == 'J' || buf[s] == 'I' ||
+                 buf[s] == '\'' || buf[s] == ';')) {
+                int note_chars = 1;
+
+                /* check for double misread */
+                if (s + 1 < len &&
+                    (buf[s + 1] == '&' || buf[s + 1] == 'J' ||
+                     buf[s + 1] == 'I' || buf[s + 1] == '\'' ||
+                     buf[s + 1] == ';'))
+                    note_chars = 2;
+
+                /* must be followed by space + uppercase letter */
+                if (s + note_chars < len - 1 &&
+                    buf[s + note_chars] == ' ' &&
+                    buf[s + note_chars + 1] >= 'A' &&
+                    buf[s + note_chars + 1] <= 'Z') {
+                    tmp[dst++] = note_utf8[0];
+                    tmp[dst++] = note_utf8[1];
+                    tmp[dst++] = note_utf8[2];
+                    src = s + note_chars; /* skip misread chars, keep the space */
+                    at_line_start = 0;
+                    continue;
+                }
+            }
+            at_line_start = 0;
+        }
+
+        if (buf[src] == '\n')
+            at_line_start = 1;
+
+        tmp[dst++] = buf[src++];
+    }
+
+    memcpy(buf, tmp, dst);
+    av_free(tmp);
+    return dst;
+}
+
+static int ocr_subtitle_encode(AVCodecContext *avctx, uint8_t *buf,
+                               int bufsize, const AVSubtitle *sub)
+{
+    OCRSubtitleContext *ctx = avctx->priv_data;
+    int total = 0;
+
+    for (unsigned i = 0; i < sub->num_rects; i++) {
+        const AVSubtitleRect *rect = sub->rects[i];
+        char *text = NULL;
+        int len, ret;
+
+        if (rect->type != SUBTITLE_BITMAP)
+            continue;
+
+        ret = ocr_bitmap_rect(avctx, rect, &text);
+        if (ret < 0)
+            return ret;
+        if (!text)
+            continue;
+
+        len = trim_trailing(text, strlen(text));
+        if (len <= 0) {
+            TessDeleteText(text);
+            continue;
+        }
+
+        /* Separate multiple rects with a newline */
+        if (total > 0) {
+            if (total + 1 > bufsize) {
+                TessDeleteText(text);
+                return AVERROR_BUFFER_TOO_SMALL;
+            }
+            buf[total++] = '\n';
+        }
+
+        if (total + len > bufsize) {
+            TessDeleteText(text);
+            return AVERROR_BUFFER_TOO_SMALL;
+        }
+
+        memcpy(buf + total, text, len);
+        total += len;
+        TessDeleteText(text);
+    }
+
+    if (ctx->fixups && total > 0)
+        total = fix_music_notes(buf, total, bufsize);
+
+    return total;
+}
+
+static av_cold int ocr_subtitle_close(AVCodecContext *avctx)
+{
+    OCRSubtitleContext *ctx = avctx->priv_data;
+
+    if (ctx->tess) {
+        TessBaseAPIEnd(ctx->tess);
+        TessBaseAPIDelete(ctx->tess);
+        ctx->tess = NULL;
+    }
+
+    return 0;
+}
+
+#define OFFSET(x) offsetof(OCRSubtitleContext, x)
+#define E (AV_OPT_FLAG_ENCODING_PARAM | AV_OPT_FLAG_SUBTITLE_PARAM)
+
+static const AVOption ocr_subtitle_options[] = {
+    { "ocr_language", "Tesseract OCR language (auto-detected from stream, falls back to eng)",
+      OFFSET(language), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, E },
+    { "datapath", "Path to Tesseract tessdata directory",
+      OFFSET(datapath), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, E },
+    { "ocr_fixups", "Apply post-processing fixes for common OCR misreads (e.g. music notes)",
+      OFFSET(fixups), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, E },
+    { "ocr_scale", "Upscale factor for bitmap before OCR (improves accuracy and line detection)",
+      OFFSET(scale), AV_OPT_TYPE_INT, { .i64 = 3 }, 1, 8, E },
+    { NULL },
+};
+
+static const AVClass ocr_subtitle_class = {
+    .class_name = "OCR subtitle encoder",
+    .item_name  = av_default_item_name,
+    .option     = ocr_subtitle_options,
+    .version    = LIBAVUTIL_VERSION_INT,
+};
+
+const FFCodec ff_ocr_subtitle_encoder = {
+    .p.name         = "ocr_subtitle",
+    .p.long_name    = NULL_IF_CONFIG_SMALL("OCR bitmap-to-text subtitle encoder"),
+    .p.type         = AVMEDIA_TYPE_SUBTITLE,
+    .p.id           = AV_CODEC_ID_WEBVTT,
+    .p.priv_class   = &ocr_subtitle_class,
+    .priv_data_size = sizeof(OCRSubtitleContext),
+    .init           = ocr_subtitle_init,
+    FF_CODEC_ENCODE_SUB_CB(ocr_subtitle_encode),
+    .close          = ocr_subtitle_close,
+};

--- a/tests/tests.ps1
+++ b/tests/tests.ps1
@@ -202,6 +202,9 @@ run_test "libxml2" "-hide_banner -version | findstr xml" "xml"
 run_test "libdav1d" "-hide_banner -decoders" "dav1d"
 run_test "librav1e" "-hide_banner -encoders" "rav1e"
 
+# OCR subtitle encoder
+run_test "ocr_subtitle" "-hide_banner -encoders" "ocr_subtitle"
+
 # Print summary
 Write-Host ([string]::new('-', $TOTAL_WIDTH_TEXT))
 text_with_padding "📊 Summary:" ""

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -234,6 +234,9 @@ run_test "libxml2" "-hide_banner -version | grep xml" "xml"
 run_test "libdav1d" "-hide_banner -decoders" "dav1d"
 run_test "librav1e" "-hide_banner -encoders" "rav1e"
 
+# OCR subtitle encoder
+run_test "ocr_subtitle" "-hide_banner -encoders" "ocr_subtitle"
+
 # Print summary
 printf "%${TOTAL_WIDTH_TEXT}s\n" | tr ' ' '-' # Print a horizontal line
 text_with_padding "📊 Summary:" ""


### PR DESCRIPTION
Closes #9

## Summary

- Adds `ocr_subtitle` encoder that converts DVD/Blu-ray bitmap subtitles to text (WebVTT, SRT) using Tesseract OCR — entirely within FFmpeg
- Luminance-weighted grayscale conversion with 3x upscale for optimal OCR accuracy
- Auto-detects language from input stream metadata, falls back to `eng`, overridable via `-ocr_language`
- Optional `-ocr_fixups 1` flag for common Tesseract misreads (music note symbols)
- Patches `fftools/ffmpeg_mux_init.c` to allow bitmap-to-text subtitle transcoding

## Usage

```bash
# Basic — language auto-detected from stream
ffmpeg -i movie.mkv -map 0:s:0 -c:s ocr_subtitle output.vtt

# With music note fixups
ffmpeg -i movie.mkv -map 0:s:0 -c:s ocr_subtitle -ocr_fixups 1 output.vtt

# Explicit language override
ffmpeg -i movie.mkv -map 0:s:0 -c:s ocr_subtitle -ocr_language fra output.vtt
```

## Files

| File | Purpose |
|------|---------|
| `scripts/includes/ocr_subtitle_enc.c` | Encoder source (~300 lines) |
| `scripts/52-ocr-subtitle-encoder.sh` | Build injection (5 steps: allcodecs, Makefile, configure, mux_init bitmap gate, mux_init language detection) |
| `tests/tests.sh` | Added `ocr_subtitle` encoder presence test |
| `tests/tests.ps1` | Added `ocr_subtitle` encoder presence test |
| `UPDATE.md` | v1.0.30 (VOBsub muxer) + v1.0.31 (OCR encoder) release notes |

## Test plan

- [x] Encoder registered on all 5 platforms (Windows x86_64, Linux x86_64/aarch64, macOS x86_64/arm64)
- [x] DVD subtitle → WebVTT conversion (321 events, Darkwing Duck S01E01)
- [x] Language auto-detection from stream metadata (`eng`)
- [x] Language override (`-ocr_language fra`)
- [x] Invalid language → clear error with traineddata path hint
- [x] Music note fixups (`-ocr_fixups 1`) — J/&/;/' → ♪
- [x] Dialogue accuracy near-perfect with luminance conversion