### PR TITLE
feat: add chapter VTT muxer for direct chapter-to-WebVTT output

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -152,6 +152,61 @@ This feature enables the NoMercy MediaServer to:
 # Extract DVD subtitles to VobSub pair
 ffmpeg -i movie.mkv -map 0:s:0 -c:s copy output.idx
 # produces output.idx (text index) + output.sub (bitmap data)
+
+---
+
+### v1.0.32 - April 13, 2026
+
+#### 📑 Added Chapter VTT Muxer
+
+**New Feature: Direct Chapter-to-WebVTT Output**
+
+Added a custom `chapters_vtt` muxer that reads chapter metadata from input containers (MKV, MP4, etc.) and writes a standard WebVTT chapter file. This eliminates the need for ffprobe JSON parsing when extracting chapter information.
+
+#### What's New
+- **Chapter Extraction**: Reads chapter metadata directly from any container format FFmpeg supports
+- **WebVTT Output**: Produces spec-compliant WebVTT chapter files with proper timestamp formatting
+- **No Stream Mapping**: Works with `-f chapters_vtt` alone — no `-map` flags needed (AVFMT_NOSTREAMS)
+- **Graceful Fallback**: Uses "Chapter N" titles when chapters have no title metadata
+- **Cross-Platform**: Available on all supported platforms (Linux x86_64/aarch64, Windows x86_64/arm64, macOS x86_64/ARM64)
+
+#### Technical Details
+- Implementation: `libavformat/chaptervttenc.c`
+- Build script: `scripts/54-chapter-vtt-muxer.sh`
+- FFmpeg flags: `AVFMT_NOSTREAMS | AVFMT_NOTIMESTAMPS`
+- Symbol: `ff_chapters_vtt_muxer`
+- Registration: injected into `allformats.c` and `Makefile` at build time
+
+#### Use Case
+This feature enhances the NoMercy MediaServer's ability to:
+- Extract chapter markers from MKV and MP4 files into WebVTT for the video player
+- Provide chapter navigation in the web and native clients
+- Replace multi-step ffprobe JSON pipelines with a single FFmpeg command
+
+#### Usage Examples
+```bash
+# Extract chapters from an MKV to a WebVTT file
+ffmpeg -i input.mkv -f chapters_vtt chapters.vtt
+
+# Pipe chapter output to stdout
+ffmpeg -i input.mp4 -f chapters_vtt pipe:1
+
+# Verify the muxer is available
+ffmpeg -hide_banner -muxers | grep chapters_vtt
+```
+
+#### Example Output
+```
+WEBVTT
+
+00:00:00.000 --> 00:05:23.456
+Introduction
+
+00:05:23.456 --> 00:15:47.890
+Act One
+
+00:15:47.890 --> 00:45:12.345
+Act Two
 ```
 
 ---

--- a/scripts/54-chapter-vtt-muxer.sh
+++ b/scripts/54-chapter-vtt-muxer.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#/**************************************/#
+#/*  NoMercy Entertainment — Chapter   */#
+#/*  VTT muxer for chapter metadata    */#
+#/**************************************/#
+
+# Copy the custom muxer source into the FFmpeg source tree
+cp /scripts/includes/chaptervttenc.c /build/ffmpeg/libavformat/chaptervttenc.c
+
+# 1. Register the muxer extern declaration in allformats.c
+log "Step 1: Adding extern declaration to allformats.c"
+
+if ! grep -q "ff_chapters_vtt_muxer" /build/ffmpeg/libavformat/allformats.c; then
+    sed -i '/^extern const FFOutputFormat ff_chromaprint_muxer;$/a\extern const FFOutputFormat ff_chapters_vtt_muxer;' /build/ffmpeg/libavformat/allformats.c
+    log "  Added extern declaration"
+else
+    log "  Extern declaration already exists"
+fi
+
+# Verify
+if grep -q "ff_chapters_vtt_muxer" /build/ffmpeg/libavformat/allformats.c; then
+    log "  Verified in allformats.c"
+else
+    log "  ERROR: Verification failed!"
+    exit 1
+fi
+
+# 2. Add the muxer object to the Makefile
+log "Step 2: Adding to Makefile"
+
+if ! grep -q "chaptervttenc.o" /build/ffmpeg/libavformat/Makefile; then
+    sed -i '/^OBJS-\$(CONFIG_CHROMAPRINT_MUXER)/a\OBJS-$(CONFIG_CHAPTERS_VTT_MUXER)          += chaptervttenc.o' /build/ffmpeg/libavformat/Makefile
+    log "  Added to Makefile"
+else
+    log "  Makefile entry already exists"
+fi
+
+# Verify
+if grep -q "chaptervttenc.o" /build/ffmpeg/libavformat/Makefile; then
+    log "  Verified in Makefile"
+else
+    log "  ERROR: Verification failed!"
+    exit 1
+fi
+
+exit 0

--- a/scripts/includes/chaptervttenc.c
+++ b/scripts/includes/chaptervttenc.c
@@ -1,0 +1,112 @@
+/*
+ * Chapter VTT muxer
+ * Copyright (c) 2026 NoMercy Entertainment
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * Chapter VTT muxer
+ *
+ * Reads chapter metadata from the input container (MKV, MP4, etc.)
+ * and writes a standard WebVTT chapter file.
+ *
+ *   ffmpeg -i input.mkv -f chapters_vtt chapters.vtt
+ *
+ * No stream mapping is required (AVFMT_NOSTREAMS).
+ */
+
+#include "avformat.h"
+#include "internal.h"
+#include "mux.h"
+#include "libavutil/avstring.h"
+
+/**
+ * Format milliseconds into a WebVTT timestamp: HH:MM:SS.mmm
+ */
+static void format_vtt_time(char *buf, size_t buf_size, int64_t ms)
+{
+    int h  = (int)(ms / 3600000);
+    int m  = (int)((ms % 3600000) / 60000);
+    int s  = (int)((ms % 60000) / 1000);
+    int ml = (int)(ms % 1000);
+    snprintf(buf, buf_size, "%02d:%02d:%02d.%03d", h, m, s, ml);
+}
+
+static int chapters_vtt_write_header(AVFormatContext *s)
+{
+    unsigned int i;
+
+    avio_printf(s->pb, "WEBVTT\n\n");
+
+    if (s->nb_chapters == 0) {
+        av_log(s, AV_LOG_WARNING,
+               "No chapters found in input — writing empty WebVTT file\n");
+        return 0;
+    }
+
+    for (i = 0; i < s->nb_chapters; i++) {
+        AVChapter *chapter = s->chapters[i];
+        AVDictionaryEntry *title;
+        char start_buf[32], end_buf[32];
+        int64_t start_ms, end_ms;
+
+        start_ms = av_rescale_q(chapter->start, chapter->time_base,
+                                (AVRational){1, 1000});
+        end_ms   = av_rescale_q(chapter->end,   chapter->time_base,
+                                (AVRational){1, 1000});
+
+        format_vtt_time(start_buf, sizeof(start_buf), start_ms);
+        format_vtt_time(end_buf,   sizeof(end_buf),   end_ms);
+
+        title = av_dict_get(chapter->metadata, "title", NULL, 0);
+
+        if (title && title->value[0] != '\0')
+            avio_printf(s->pb, "%s --> %s\n%s\n\n",
+                        start_buf, end_buf, title->value);
+        else
+            avio_printf(s->pb, "%s --> %s\nChapter %u\n\n",
+                        start_buf, end_buf, i + 1);
+    }
+
+    return 0;
+}
+
+static int chapters_vtt_write_packet(AVFormatContext *s, AVPacket *pkt)
+{
+    return 0;
+}
+
+static int chapters_vtt_write_trailer(AVFormatContext *s)
+{
+    avio_flush(s->pb);
+    return 0;
+}
+
+const FFOutputFormat ff_chapters_vtt_muxer = {
+    .p.name           = "chapters_vtt",
+    .p.long_name      = NULL_IF_CONFIG_SMALL("WebVTT chapter file"),
+    .p.extensions     = "vtt",
+    .p.video_codec    = AV_CODEC_ID_NONE,
+    .p.audio_codec    = AV_CODEC_ID_NONE,
+    .p.subtitle_codec = AV_CODEC_ID_NONE,
+    .p.flags          = AVFMT_NOSTREAMS | AVFMT_NOTIMESTAMPS,
+    .write_header     = chapters_vtt_write_header,
+    .write_packet     = chapters_vtt_write_packet,
+    .write_trailer    = chapters_vtt_write_trailer,
+};

--- a/tests/tests.ps1
+++ b/tests/tests.ps1
@@ -184,6 +184,7 @@ run_test "libopenjpeg" "-y -i $SampleImage -c:v libopenjpeg $TestRoot\test_jp2.j
 run_test "libass" "-y -i $SampleVideo -vf `"ass=$SampleSubs`" $TestRoot\test_ass.mp4" "ass"
 run_test "vobsub_muxer" "-hide_banner -muxers" "vobsub"
 run_test "spritevtt_muxer" "-hide_banner -muxers" "spritevtt"
+run_test "chapters_vtt_muxer" "-hide_banner -muxers" "chapters_vtt"
 
 # Hardware acceleration (may fail if no hardware support)
 run_test "NVENC" "-y -i $SampleVideo -c:v h264_nvenc $TestRoot\test_nvenc.mp4" "nvenc"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -216,6 +216,7 @@ run_test "libopenjpeg" "-y -i ${SampleImage} -c:v libopenjpeg ${TestRoot}/test_j
 run_test "libass" "-y -i ${SampleVideo} -vf \"ass=${SampleSubs}\" ${TestRoot}/test_ass.mp4" "ass"
 run_test "vobsub_muxer" "-hide_banner -muxers" "vobsub"
 run_test "spritevtt_muxer" "-hide_banner -muxers" "spritevtt"
+run_test "chapters_vtt_muxer" "-hide_banner -muxers" "chapters_vtt"
 
 # Hardware acceleration (may fail if no hardware support)
 run_test "NVENC" "-y -i ${SampleVideo} -c:v h264_nvenc ${TestRoot}/test_nvenc.mp4" "nvenc"


### PR DESCRIPTION
## Summary
- Adds a `chapters_vtt` muxer that reads chapter metadata from input containers (MKV, MP4, etc.) and writes a standard WebVTT chapter file
- Eliminates the need for ffprobe JSON parsing + C# reassembly in the media server
- No stream mapping required (`AVFMT_NOSTREAMS`) — just `ffmpeg -i input.mkv -f chapters_vtt chapters.vtt`

## Implementation
- **Source**: `scripts/includes/chaptervttenc.c` — reads `AVFormatContext->chapters[]`, converts timestamps via `av_rescale_q`, writes WebVTT cues with chapter titles (falls back to "Chapter N" if no title metadata)
- **Build script**: `scripts/54-chapter-vtt-muxer.sh` — registers `ff_chapters_vtt_muxer` in allformats.c and Makefile
- **Tests**: Registration check (`-hide_banner -muxers | grep chapters_vtt`) in both tests.sh and tests.ps1

Closes #11