### PR TITLE
feat: auto-create output directories when path doesn't exist

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -207,6 +207,49 @@ Act One
 
 00:15:47.890 --> 00:45:12.345
 Act Two
+
+---
+
+### v1.0.33 - April 13, 2026
+
+#### 📁 Added Auto-Create Output Directories
+
+**Problem**: When writing output files to paths with subdirectories that don't exist yet, FFmpeg fails with "No such file or directory". Users had to manually run `mkdir -p` before every FFmpeg command targeting nested output paths.
+
+#### What's New
+- **Automatic Directory Creation**: FFmpeg now creates parent directories automatically when writing output files
+- **Cross-Platform**: Works on Linux, Windows (MinGW), and macOS with proper path separator handling
+- **Protocol-Aware**: Skips URL-based paths (http://, rtmp://, etc.) — only creates directories for local file paths
+- **Write-Only**: Only triggers for output files (AVIO_FLAG_WRITE), never for input paths
+- **Silent Fallback**: If directory creation fails (permissions, etc.), the original FFmpeg error is preserved
+
+#### Technical Details
+- Patched file: `libavformat/aviobuf.c` (avio_open2 function)
+- Build script: `scripts/55-auto-create-dirs.sh`
+- Uses FFmpeg memory allocators (av_strndup/av_free)
+- Handles both `/` and `\` path separators
+
+#### Use Case
+This feature is essential for the NoMercy MediaServer's encoding pipeline:
+- HLS output with segment subdirectories (`output/stream_0/segment_%03d.ts`)
+- Organized transcoding output trees (`output/1080p/video.mp4`)
+- Batch processing with structured output paths
+- Any workflow where output paths include directories that may not exist yet
+
+#### Usage Examples
+```bash
+# Before: required manual mkdir
+mkdir -p /output/hls/stream_0
+ffmpeg -i input.mp4 -c copy /output/hls/stream_0/segment_%03d.ts
+
+# After: just works
+ffmpeg -i input.mp4 -c copy /output/hls/stream_0/segment_%03d.ts
+
+# Nested output paths work automatically
+ffmpeg -i input.mp4 -c:v libx264 /videos/2026/04/encoded/output.mp4
+
+# Network URLs are unaffected
+ffmpeg -i input.mp4 -f flv rtmp://server/live/stream
 ```
 
 ---

--- a/scripts/55-auto-create-dirs.sh
+++ b/scripts/55-auto-create-dirs.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+#/**************************************/#
+#/*  NoMercy Entertainment — Auto      */#
+#/*  create output directories         */#
+#/**************************************/#
+
+# Patch avio_open2 in aviobuf.c to auto-create parent directories
+# when opening files for writing. This eliminates "No such file or
+# directory" errors when output paths include subdirectories.
+
+log "Step 1: Adding mkdir_p helper to aviobuf.c"
+
+# Add the necessary includes and helper function at the top of aviobuf.c,
+# after the existing #include block.
+#
+# The helper:
+# - Only acts on local file paths (skips URLs with "://")
+# - Only acts when AVIO_FLAG_WRITE is set
+# - Creates parent directories recursively
+# - Cross-platform: uses _mkdir on Windows, mkdir on Unix
+# - Handles both / and \ separators
+
+# Check if already patched
+if ! grep -q "ff_ensure_dir_exists" /build/ffmpeg/libavformat/aviobuf.c; then
+
+    # First, add the includes and helper function after the last #include
+    cat > /tmp/mkdir_patch.c << 'MKDIRPATCH'
+
+/* --- NoMercy: auto-create output directories --- */
+#include <sys/stat.h>
+#ifdef _WIN32
+#include <direct.h>
+#define ff_local_mkdir(p) _mkdir(p)
+#else
+#define ff_local_mkdir(p) mkdir(p, 0755)
+#endif
+
+/**
+ * Recursively create parent directories for a file path.
+ * Only operates on local file paths (no protocol prefix).
+ */
+static void ff_ensure_dir_exists(const char *path, int flags)
+{
+    char *tmp, *sep;
+
+    /* Only create dirs for output files */
+    if (!(flags & AVIO_FLAG_WRITE))
+        return;
+
+    /* Skip non-local paths (URLs with protocol) */
+    if (!path || strstr(path, "://"))
+        return;
+
+    /* Find the last directory separator */
+    sep = NULL;
+    for (char *p = (char *)path; *p; p++) {
+        if (*p == '/' || *p == '\\')
+            sep = p;
+    }
+
+    /* No directory component — file is in current dir */
+    if (!sep || sep == path)
+        return;
+
+    tmp = av_strndup(path, sep - path);
+    if (!tmp)
+        return;
+
+    /* Recursively create directories */
+    for (char *p = tmp + 1; *p; p++) {
+        if (*p == '/' || *p == '\\') {
+            char saved = *p;
+            *p = '\0';
+            ff_local_mkdir(tmp);
+            *p = saved;
+        }
+    }
+    ff_local_mkdir(tmp);
+    av_free(tmp);
+}
+/* --- End NoMercy patch --- */
+MKDIRPATCH
+
+    # Find the last #include line in aviobuf.c and insert after it
+    last_include_line=$(grep -n '^#include' /build/ffmpeg/libavformat/aviobuf.c | tail -1 | cut -d: -f1)
+
+    if [ -z "$last_include_line" ]; then
+        log "  ERROR: Could not find #include lines in aviobuf.c"
+        exit 1
+    fi
+
+    # Insert the helper function after the last #include
+    sed -i "${last_include_line}r /tmp/mkdir_patch.c" /build/ffmpeg/libavformat/aviobuf.c
+
+    rm -f /tmp/mkdir_patch.c
+    log "  Added mkdir_p helper function"
+else
+    log "  Helper function already exists"
+fi
+
+# Verify helper was added
+if grep -q "ff_ensure_dir_exists" /build/ffmpeg/libavformat/aviobuf.c; then
+    log "  Verified helper function in aviobuf.c"
+else
+    log "  ERROR: Helper function verification failed!"
+    exit 1
+fi
+
+# Step 2: Patch avio_open2 to call the helper
+log "Step 2: Patching avio_open2 to auto-create directories"
+
+if ! grep -q "ff_ensure_dir_exists(filename, flags)" /build/ffmpeg/libavformat/aviobuf.c; then
+    # We need to find the avio_open2 function body and add the call
+    # at the very beginning of the function, after the opening brace.
+    # The function signature is:
+    #   int avio_open2(AVIOContext **s, const char *filename, int flags,
+    #                  const AVIOInterruptCB *int_cb, AVDictionary **options)
+
+    # Add the call right after the opening brace of avio_open2
+    # Use awk to find the function and insert after {
+    awk '
+    /^int avio_open2\(/ { in_func=1 }
+    in_func && /\{/ {
+        print
+        print "    ff_ensure_dir_exists(filename, flags);"
+        in_func=0
+        next
+    }
+    { print }
+    ' /build/ffmpeg/libavformat/aviobuf.c > /tmp/aviobuf_patched.c \
+        && mv /tmp/aviobuf_patched.c /build/ffmpeg/libavformat/aviobuf.c
+
+    log "  Patched avio_open2"
+else
+    log "  avio_open2 already patched"
+fi
+
+# Verify the patch
+if grep -A5 "avio_open2" /build/ffmpeg/libavformat/aviobuf.c | grep -q "ff_ensure_dir_exists"; then
+    log "  Verified avio_open2 patch"
+else
+    log "  ERROR: avio_open2 patch verification failed!"
+    exit 1
+fi
+
+exit 0

--- a/tests/tests.ps1
+++ b/tests/tests.ps1
@@ -186,6 +186,9 @@ run_test "vobsub_muxer" "-hide_banner -muxers" "vobsub"
 run_test "spritevtt_muxer" "-hide_banner -muxers" "spritevtt"
 run_test "chapters_vtt_muxer" "-hide_banner -muxers" "chapters_vtt"
 
+# Auto-create directories
+run_test "auto_mkdir" "-y -f lavfi -i `"testsrc=duration=1:size=320x240:rate=1`" -frames:v 1 $TestRoot\subdir_test\nested\output.png" "output.png"
+
 # Hardware acceleration (may fail if no hardware support)
 run_test "NVENC" "-y -i $SampleVideo -c:v h264_nvenc $TestRoot\test_nvenc.mp4" "nvenc"
 run_test "VPL" "-y -i $SampleVideo -c:v h264_vpl $TestRoot\test_vpl.mp4" "vpl"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -218,6 +218,9 @@ run_test "vobsub_muxer" "-hide_banner -muxers" "vobsub"
 run_test "spritevtt_muxer" "-hide_banner -muxers" "spritevtt"
 run_test "chapters_vtt_muxer" "-hide_banner -muxers" "chapters_vtt"
 
+# Auto-create directories
+run_test "auto_mkdir" "-y -f lavfi -i \"testsrc=duration=1:size=320x240:rate=1\" -frames:v 1 ${TestRoot}/subdir_test/nested/output.png" "output.png"
+
 # Hardware acceleration (may fail if no hardware support)
 run_test "NVENC" "-y -i ${SampleVideo} -c:v h264_nvenc ${TestRoot}/test_nvenc.mp4" "nvenc"
 run_test "VPL" "-y -i ${SampleVideo} -c:v h264_vpl ${TestRoot}/test_vpl.mp4" "vpl"


### PR DESCRIPTION
## Summary
- Patches `avio_open2` to auto-create parent directories when writing output files
- Eliminates "No such file or directory" errors for paths with subdirectories
- Critical for HLS output where variant streams map to subdirectories

## Implementation
- **Build script**: `scripts/55-auto-create-dirs.sh` — injects `ff_ensure_dir_exists()` helper into `libavformat/aviobuf.c` and patches `avio_open2` to call it
- **Cross-platform**: `_mkdir` on Windows (via `<direct.h>`), `mkdir` on Unix (via `<sys/stat.h>`)
- **Safety**: only acts on `AVIO_FLAG_WRITE`, skips URLs with `://` protocol prefix, handles both `/` and `\` separators
- **Tests**: Functional test that writes to a nested subdirectory (`subdir_test/nested/output.png`) in both tests.sh and tests.ps1

## Scope
- Applies to all output file opens (avio_open, avio_open2)
- Applies to companion files (e.g. .idx from VOBsub muxer, .vtt from sprite muxer)
- Applies to HLS segment filenames and playlist paths
- Does NOT create directories for input paths

Closes #13