### PR TITLE
perf: per-script Docker caching + test reliability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,7 +157,7 @@ jobs:
   export-artifacts:
     runs-on: [self-hosted, beast-unit]
     needs: [detect-changes, build-linux-x86_64, build-linux-aarch64, build-windows-x86_64, build-darwin-x86_64, build-darwin-arm64]
-    if: always() && (needs.detect-changes.outputs.any-changed == 'true' || inputs.force_rebuild) && (needs.build-linux-x86_64.result != 'failure' || needs.build-linux-aarch64.result != 'failure' || needs.build-windows-x86_64.result != 'failure' || needs.build-darwin-x86_64.result != 'failure' || needs.build-darwin-arm64.result != 'failure')
+    if: always() && (needs.detect-changes.outputs.any-changed == 'true' || inputs.force_rebuild) && needs.build-linux-x86_64.result == 'success' && needs.build-linux-aarch64.result == 'success' && needs.build-windows-x86_64.result == 'success' && needs.build-darwin-x86_64.result == 'success' && needs.build-darwin-arm64.result == 'success'
     steps:
       - name: Cache Downloaded Artifacts
         uses: actions/cache@v4

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -214,7 +214,7 @@ jobs:
               fi
             fi
           done
-        timeout-minutes: 180  # 3 hour timeout for builds
+        timeout-minutes: 240  # 4 hour timeout — Windows cross-compile on fuse-overlayfs runs ~3h
 
       - name: Push to DockerHub
         if: success()

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -107,14 +107,10 @@ jobs:
 
       - name: Set up Docker Buildx
         run: |
-          # Use a per-platform named builder to reuse across runs and avoid random buildkit containers
-          BUILDER_NAME="builder-${{ inputs.platform }}"
-          if docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1; then
-            docker buildx use "$BUILDER_NAME"
-          else
-            docker buildx create --use --name "$BUILDER_NAME" --driver docker-container --driver-opt network=host
-          fi
-          docker buildx inspect --bootstrap
+          # Use default docker driver — no nested buildkit container,
+          # avoids overlay-on-overlay issues in DinD runners
+          docker buildx use default
+          docker buildx inspect
 
       - name: Create Cache Directories
         run: |
@@ -166,38 +162,26 @@ jobs:
           cp -r nomercy-ffmpeg-secrets/* ${{ github.workspace }}/scripts/
           rm -rf nomercy-ffmpeg-secrets
 
-      - name: Build and Push Docker Image with Retry
+      - name: Build Docker Image with Retry
         run: |
           source error_handler.sh
-          # Build configuration
+          IMAGE="nomercyentertainment/ffmpeg-${{ inputs.platform }}"
+
+          NO_CACHE_FLAG=""
           if [[ "${{ inputs.no_cache }}" == "true" ]]; then
-            echo "🔥 No-cache build: skipping all layer caches"
-            BUILD_ARGS="--file ${{ inputs.dockerfile }} \
-              --tag nomercyentertainment/ffmpeg-${{ inputs.platform }}:latest \
-              --tag nomercyentertainment/ffmpeg-${{ inputs.platform }}:${{ github.sha }} \
-              --no-cache \
-              --platform linux/amd64 \
-              --build-arg BUILDKIT_INLINE_CACHE=1 \
-              --build-arg DOCKER_BUILDKIT=1 \
-              --push \
-              ${{ inputs.context }}"
-          else
-            BUILD_ARGS="--file ${{ inputs.dockerfile }} \
-              --tag nomercyentertainment/ffmpeg-${{ inputs.platform }}:latest \
-              --tag nomercyentertainment/ffmpeg-${{ inputs.platform }}:${{ github.sha }} \
-              --cache-from type=registry,ref=nomercyentertainment/ffmpeg-${{ inputs.platform }}:buildcache \
-              --cache-from type=registry,ref=nomercyentertainment/ffmpeg-base:buildcache \
-              --cache-from type=local,src=~/.docker/buildx-cache \
-              --cache-to type=registry,ref=nomercyentertainment/ffmpeg-${{ inputs.platform }}:buildcache,mode=max \
-              --cache-to type=local,dest=~/.docker/buildx-cache-new,mode=max \
-              --platform linux/amd64 \
-              --build-arg BUILDKIT_INLINE_CACHE=1 \
-              --build-arg DOCKER_BUILDKIT=1 \
-              --push \
-              ${{ inputs.context }}"
+            echo "🔥 No-cache build"
+            NO_CACHE_FLAG="--no-cache"
           fi
 
-          # Retry build with error recovery
+          # docker driver = host dockerd builder, no nested container
+          # Build + load locally, then push separately
+          BUILD_ARGS="--file ${{ inputs.dockerfile }} \
+            --tag ${IMAGE}:latest \
+            --tag ${IMAGE}:${{ github.sha }} \
+            ${NO_CACHE_FLAG} \
+            --load \
+            ${{ inputs.context }}"
+
           MAX_BUILD_ATTEMPTS=2
           for attempt in $(seq 1 $MAX_BUILD_ATTEMPTS); do
             echo "🔄 Build attempt $attempt/$MAX_BUILD_ATTEMPTS"
@@ -231,6 +215,14 @@ jobs:
             fi
           done
         timeout-minutes: 180  # 3 hour timeout for builds
+
+      - name: Push to DockerHub
+        if: success()
+        run: |
+          source error_handler.sh
+          IMAGE="nomercyentertainment/ffmpeg-${{ inputs.platform }}"
+          docker_retry "docker push ${IMAGE}:latest"
+          docker_retry "docker push ${IMAGE}:${{ github.sha }}"
 
       - name: Upload Build Failure Report
         if: failure()

--- a/ffmpeg-base.dockerfile
+++ b/ffmpeg-base.dockerfile
@@ -93,6 +93,8 @@ RUN echo "------------------------------------------------------" \
     && echo "------------------------------------------------------" \
     && echo "🔧 Start downloading and installing dependencies" \
     && echo "------------------------------------------------------"\
+    && echo "🔄 Swapping apt mirror to Leaseweb NL for speed" \
+    && sed -i 's|http://archive.ubuntu.com|http://mirror.nl.leaseweb.net|g' /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true \
     && echo "🔄 Checking for updates" \
     && apt-get update >/dev/null 2>&1 \
     && echo "✅ Updating completed successfully" \

--- a/scripts/50-librsvg.sh
+++ b/scripts/50-librsvg.sh
@@ -157,7 +157,14 @@ cd /build
 # Download glib
 if [ ! -d "/build/glib" ]; then
 	echo "Downloading glib..."
-	git clone --branch ${LIBGLIB_VERSION} https://gitlab.gnome.org/GNOME/glib.git glib >/dev/null 2>&1
+	git clone --branch ${LIBGLIB_VERSION} --depth 1 https://gitlab.gnome.org/GNOME/glib.git /build/glib
+	# Pre-clone gvdb subproject — meson wrap-git fails inside Docker
+	if [ -f "/build/glib/subprojects/gvdb.wrap" ] && [ ! -d "/build/glib/subprojects/gvdb" ]; then
+		gvdb_url=$(grep 'url=' /build/glib/subprojects/gvdb.wrap | head -1 | cut -d= -f2)
+		gvdb_rev=$(grep 'revision=' /build/glib/subprojects/gvdb.wrap | head -1 | cut -d= -f2)
+		git clone "${gvdb_url}" /build/glib/subprojects/gvdb
+		cd /build/glib/subprojects/gvdb && git checkout "${gvdb_rev}" 2>/dev/null
+	fi
 fi
 
 cd /build/glib

--- a/scripts/55-auto-create-dirs.sh
+++ b/scripts/55-auto-create-dirs.sh
@@ -5,142 +5,158 @@
 #/*  create output directories         */#
 #/**************************************/#
 
-# Patch avio_open2 in aviobuf.c to auto-create parent directories
-# when opening files for writing. This eliminates "No such file or
-# directory" errors when output paths include subdirectories.
-
-log "Step 1: Adding mkdir_p helper to aviobuf.c"
-
-# Add the necessary includes and helper function at the top of aviobuf.c,
-# after the existing #include block.
+# Patch io_open_default in libavformat/options.c to auto-create parent
+# directories when opening files for writing. This is the actual entry
+# point used by muxers (image2, mp4, mkv, etc.) — NOT avio_open2.
 #
-# The helper:
-# - Only acts on local file paths (skips URLs with "://")
-# - Only acts when AVIO_FLAG_WRITE is set
-# - Creates parent directories recursively
-# - Cross-platform: uses _mkdir on Windows, mkdir on Unix
-# - Handles both / and \ separators
+# Works cross-platform: uses _mkdir on Windows, mkdir on Unix.
 
-# Check if already patched
-if ! grep -q "ff_ensure_dir_exists" /build/ffmpeg/libavformat/aviobuf.c; then
+OPTIONS_FILE="/build/ffmpeg/libavformat/options.c"
 
-    # First, add the includes and helper function after the last #include
+if [ ! -f "$OPTIONS_FILE" ]; then
+    log "  ERROR: $OPTIONS_FILE not found"
+    exit 1
+fi
+
+log "  Patching: $OPTIONS_FILE"
+
+# --- Step 1: Add ff_ensure_dir_exists helper function ---
+log "Step 1: Adding ff_ensure_dir_exists helper"
+
+if ! grep -q "ff_ensure_dir_exists" "$OPTIONS_FILE"; then
+
     cat > /tmp/mkdir_patch.c << 'MKDIRPATCH'
 
 /* --- NoMercy: auto-create output directories --- */
 #include <sys/stat.h>
+#include <errno.h>
 #ifdef _WIN32
-#include <direct.h>
-#define ff_local_mkdir(p) _mkdir(p)
+#  include <direct.h>
+#  define ff_local_mkdir(p) _mkdir(p)
 #else
-#define ff_local_mkdir(p) mkdir(p, 0755)
+#  define ff_local_mkdir(p) mkdir(p, 0755)
 #endif
 
 /**
  * Recursively create parent directories for a file path.
  * Only operates on local file paths (no protocol prefix).
+ * Safe to call when directories already exist (ignores EEXIST).
  */
-static void ff_ensure_dir_exists(const char *path, int flags)
+static void ff_ensure_dir_exists(const char *url, int flags)
 {
-    char *tmp, *sep;
+    char *tmp;
+    const char *sep;
 
     /* Only create dirs for output files */
     if (!(flags & AVIO_FLAG_WRITE))
         return;
 
     /* Skip non-local paths (URLs with protocol) */
-    if (!path || strstr(path, "://"))
+    if (!url || strstr(url, "://"))
         return;
 
     /* Find the last directory separator */
     sep = NULL;
-    for (char *p = (char *)path; *p; p++) {
+    for (const char *p = url; *p; p++) {
         if (*p == '/' || *p == '\\')
             sep = p;
     }
 
     /* No directory component — file is in current dir */
-    if (!sep || sep == path)
+    if (!sep || sep == url)
         return;
 
-    tmp = av_strndup(path, sep - path);
+    tmp = av_strndup(url, sep - url);
     if (!tmp)
         return;
 
-    /* Recursively create directories */
-    for (char *p = tmp + 1; *p; p++) {
+    /* Recursively create directories, ignoring EEXIST.
+     * Skip root prefixes so we don't try to mkdir "C:" or "\\server". */
+    char *start = tmp + 1;
+#ifdef _WIN32
+    /* Drive letter prefix: skip past "C:\\" */
+    if (((tmp[0] >= 'A' && tmp[0] <= 'Z') || (tmp[0] >= 'a' && tmp[0] <= 'z'))
+        && tmp[1] == ':' && (tmp[2] == '/' || tmp[2] == '\\'))
+        start = tmp + 3;
+    /* UNC prefix: skip past "\\server\share" */
+    else if ((tmp[0] == '/' || tmp[0] == '\\') && tmp[0] == tmp[1]) {
+        int slashes = 0;
+        for (start = tmp + 2; *start && slashes < 2; start++)
+            if (*start == '/' || *start == '\\') slashes++;
+    }
+#endif
+    for (char *p = start; *p; p++) {
         if (*p == '/' || *p == '\\') {
             char saved = *p;
             *p = '\0';
-            ff_local_mkdir(tmp);
+            if (ff_local_mkdir(tmp) != 0 && errno != EEXIST) {
+                av_free(tmp);
+                return;
+            }
             *p = saved;
         }
     }
-    ff_local_mkdir(tmp);
+    if (ff_local_mkdir(tmp) != 0 && errno != EEXIST) {
+        /* best-effort: don't fail the open */
+    }
     av_free(tmp);
 }
 /* --- End NoMercy patch --- */
 MKDIRPATCH
 
-    # Find the last #include line in aviobuf.c and insert after it
-    last_include_line=$(grep -n '^#include' /build/ffmpeg/libavformat/aviobuf.c | tail -1 | cut -d: -f1)
+    # Insert after the last #include in options.c
+    last_include_line=$(grep -n '^#include' "$OPTIONS_FILE" | tail -1 | cut -d: -f1)
 
     if [ -z "$last_include_line" ]; then
-        log "  ERROR: Could not find #include lines in aviobuf.c"
+        log "  ERROR: Could not find #include lines in options.c"
         exit 1
     fi
 
-    # Insert the helper function after the last #include
-    sed -i "${last_include_line}r /tmp/mkdir_patch.c" /build/ffmpeg/libavformat/aviobuf.c
-
+    sed -i "${last_include_line}r /tmp/mkdir_patch.c" "$OPTIONS_FILE"
     rm -f /tmp/mkdir_patch.c
-    log "  Added mkdir_p helper function"
+    log "  Added ff_ensure_dir_exists helper"
 else
-    log "  Helper function already exists"
+    log "  Helper already exists"
 fi
 
 # Verify helper was added
-if grep -q "ff_ensure_dir_exists" /build/ffmpeg/libavformat/aviobuf.c; then
-    log "  Verified helper function in aviobuf.c"
-else
+if ! grep -q "ff_ensure_dir_exists" "$OPTIONS_FILE"; then
     log "  ERROR: Helper function verification failed!"
     exit 1
 fi
 
-# Step 2: Patch avio_open2 to call the helper
-log "Step 2: Patching avio_open2 to auto-create directories"
+# --- Step 2: Patch io_open_default to call the helper ---
+log "Step 2: Patching io_open_default"
 
-if ! grep -q "ff_ensure_dir_exists(filename, flags)" /build/ffmpeg/libavformat/aviobuf.c; then
-    # We need to find the avio_open2 function body and add the call
-    # at the very beginning of the function, after the opening brace.
-    # The function signature is:
-    #   int avio_open2(AVIOContext **s, const char *filename, int flags,
-    #                  const AVIOInterruptCB *int_cb, AVDictionary **options)
-
-    # Add the call right after the opening brace of avio_open2
-    # Use awk to find the function and insert after {
+if ! grep -q "ff_ensure_dir_exists(url, flags)" "$OPTIONS_FILE"; then
     awk '
-    /^int avio_open2\(/ { in_func=1 }
+    /static int io_open_default\(/ { in_func=1 }
     in_func && /\{/ {
         print
-        print "    ff_ensure_dir_exists(filename, flags);"
+        print "    ff_ensure_dir_exists(url, flags);"
         in_func=0
         next
     }
     { print }
-    ' /build/ffmpeg/libavformat/aviobuf.c > /tmp/aviobuf_patched.c \
-        && mv /tmp/aviobuf_patched.c /build/ffmpeg/libavformat/aviobuf.c
+    ' "$OPTIONS_FILE" > /tmp/options_patched.c
 
-    log "  Patched avio_open2"
+    if [ -s /tmp/options_patched.c ] && grep -q "ff_ensure_dir_exists(url, flags);" /tmp/options_patched.c; then
+        mv /tmp/options_patched.c "$OPTIONS_FILE"
+        log "  Patched io_open_default"
+    else
+        rm -f /tmp/options_patched.c
+        log "  ERROR: awk failed to patch io_open_default"
+        exit 1
+    fi
 else
-    log "  avio_open2 already patched"
+    log "  io_open_default already patched"
 fi
 
 # Verify the patch
-if grep -A5 "avio_open2" /build/ffmpeg/libavformat/aviobuf.c | grep -q "ff_ensure_dir_exists"; then
-    log "  Verified avio_open2 patch"
+if grep -A5 "io_open_default" "$OPTIONS_FILE" | grep -q "ff_ensure_dir_exists"; then
+    log "  Verified io_open_default patch"
 else
-    log "  ERROR: avio_open2 patch verification failed!"
+    log "  ERROR: io_open_default patch verification failed!"
     exit 1
 fi
 

--- a/scripts/includes/spritevttenc.c
+++ b/scripts/includes/spritevttenc.c
@@ -617,7 +617,7 @@ static void spritevtt_deinit(AVFormatContext *s)
 const FFOutputFormat ff_spritevtt_muxer = {
     .p.name           = "spritevtt",
     .p.long_name      = NULL_IF_CONFIG_SMALL("Sprite sheet with WebVTT timeline"),
-    .p.extensions     = "png,webp",
+    .p.extensions     = "spritevtt",
     .p.video_codec    = AV_CODEC_ID_RAWVIDEO,
     .p.audio_codec    = AV_CODEC_ID_NONE,
     .p.subtitle_codec = AV_CODEC_ID_NONE,

--- a/tests/tests.ps1
+++ b/tests/tests.ps1
@@ -3,9 +3,13 @@ param (
 )
 
 $TOTAL_WIDTH_TEXT = 54
-$script:TOTAL_TESTS = 0
-$script:PASSED_TESTS = 0
-$script:FAILED_TESTS = 0
+$script:TOTAL = 0
+$script:PASSED = 0
+$script:FAILED = 0
+
+[Console]::OutputEncoding = [Text.Encoding]::UTF8
+$ICON_PASS = [char]0x2714
+$ICON_FAIL = [char]0x2718
 
 $TestRoot = "$Workspace\test_files"
 $SampleVideo = "$TestRoot\sample.mp4"
@@ -13,100 +17,14 @@ $SampleAudio = "$TestRoot\sample.wav"
 $SampleImage = "$TestRoot\sample.png"
 $SampleSubs = "$TestRoot\test.ass"
 
-# Cleanup and create test directory
 Remove-Item -Recurse -Force -Path $TestRoot -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Path $TestRoot -ErrorAction SilentlyContinue | Out-Null
 
-function get_test_runs_count {
-    param (
-        [string]$searchString
-    )
-    $filePath = $PSCommandPath
-    $fileContent = Get-Content -Path $filePath -Raw
-    $_matches = [regex]::Matches($fileContent, [regex]::Escape($searchString))
-    $matches_count = $_matches.Count
-    if ( $matches_count -gt 0 ) {
-        $matches_count--
-    }
-    return $matches_count
-}
-
-$TOTAL_RUNS = get_test_runs_count -searchString 'run_test "'
-
-function generate_samples {
-    $Total_Count = 0
-    $Current_Count = 0
-    $Start_Time = $null
-    $End_Time = $null
-
-    # Count needed samples
-    if (-Not (Test-Path $SampleVideo)) { $Total_Count++ }
-    if (-Not (Test-Path $SampleAudio)) { $Total_Count++ }
-    if (-Not (Test-Path $SampleImage)) { $Total_Count++ }
-    if (-Not (Test-Path $SampleSubs)) { $Total_Count++ }
-
-    # Generate samples
-    if (-Not (Test-Path $SampleVideo)) {
-        $Start_Time = Get-Date
-        $Current_Count++
-        text_with_padding "📹 Generating sample video" "[$Current_Count/$Total_Count]"
-        & "$Workspace\ffmpeg.exe" -hide_banner -y -f lavfi -i "testsrc=duration=10:size=1280x720:rate=30" -c:v libx264 -crf 23 "$SampleVideo" 2>&1 | Out-Null
-        $End_Time = Get-Date
-        text_with_padding "✅ Sample video generated" "[$((New-TimeSpan -Start $Start_Time -End $End_Time).TotalSeconds.ToString("0"))s]" 1
-    }
-
-    if (-Not (Test-Path $SampleAudio)) {
-        $Start_Time = Get-Date
-        $Current_Count++
-        text_with_padding "🔊 Generating sample audio" "[$Current_Count/$Total_Count]"
-        & "$Workspace\ffmpeg.exe" -hide_banner -y -f lavfi -i "sine=frequency=1000:duration=10" -c:a pcm_s16le "$SampleAudio" 2>&1 | Out-Null
-        $End_Time = Get-Date
-        text_with_padding "✅ Sample audio generated" "[$((New-TimeSpan -Start $Start_Time -End $End_Time).TotalSeconds.ToString("0"))s]" 1
-    }
-
-    if (-Not (Test-Path $SampleImage)) {
-        $Start_Time = Get-Date
-        $Current_Count++
-        text_with_padding "🖼️ Generating sample image" "[$Current_Count/$Total_Count]" -1
-        & "$Workspace\ffmpeg.exe" -hide_banner -y -f lavfi -i "testsrc=duration=1:size=640x480:rate=1" -frames:v 1 "$SampleImage" 2>&1 | Out-Null
-        $End_Time = Get-Date
-        text_with_padding "✅ Sample image generated" "[$((New-TimeSpan -Start $Start_Time -End $End_Time).TotalSeconds.ToString("0"))s]" 1
-    }
-
-    if (-Not (Test-Path $SampleSubs)) {
-        $Start_Time = Get-Date
-        $Current_Count++
-        text_with_padding "📝 Generating sample subtitles" "[$Current_Count/$Total_Count]"
-        @"
-[Script Info]
-Title: Test Subtitle
-ScriptType: v4.00+
-
-[V4+ Styles]
-Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,10,0
-
-[Events]
-Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
-Dialogue: 0,0:00:01.00,0:00:05.00,Default,,0,0,0,,Test subtitle
-"@ | Out-File -FilePath $SampleSubs -Encoding ASCII
-        $End_Time = Get-Date
-        text_with_padding "✅ Sample subtitles generated" "[$((New-TimeSpan -Start $Start_Time -End $End_Time).TotalSeconds.ToString("0"))s]" 1
-    }
-
-    if ($Current_Count -gt 0) {
-        Write-Host ([string]::new('-', $TOTAL_WIDTH_TEXT))
-    }
-}
-
 function text_with_padding {
-    param (
-        $text_before,
-        $text_after,
-        $extra_padding = 0
-    )
+    param ($text_before, $text_after, $extra_padding = 0)
     $text_length = $text_before.Length + $text_after.Length
     $padding = $TOTAL_WIDTH_TEXT - $text_length - $extra_padding
+    if ($padding -lt 1) { $padding = 1 }
     Write-Host -NoNewline $text_before
     Write-Host -NoNewline (" " * $padding)
     Write-Host $text_after
@@ -114,115 +32,154 @@ function text_with_padding {
 
 function check_command {
     if (-Not (Test-Path "$Workspace\ffmpeg.exe")) {
-        Write-Host "❌ FFmpeg executable not found in current directory"
+        Write-Host "$ICON_FAIL FFmpeg executable not found"
         exit 1
     }
 }
 
-function run_test {
-    param (
-        $name,
-        $command,
-        $expected_output
-    )
+function generate_samples {
+    $Total_Count = 0
+    $Current_Count = 0
 
-    $script:TOTAL_TESTS++
-    $name = $name.ToUpper()
-    text_with_padding "🧪 Testing ${name}" "[$script:TOTAL_TESTS/$TOTAL_RUNS]"
-    $Start_Time = Get-Date
-    $test_output = Invoke-Expression "$Workspace\ffmpeg.exe $command 2>&1" | Out-String
-    if ( $LASTEXITCODE -eq 0 -and $test_output -cmatch $expected_output ) {
-        $End_Time = Get-Date
-        text_with_padding "✅ ${name} test passed" "[ $((New-TimeSpan -Start $Start_Time -End $End_Time).Seconds)s ]" 1
-        $script:PASSED_TESTS++
+    if (-Not (Test-Path $SampleVideo)) { $Total_Count++ }
+    if (-Not (Test-Path $SampleAudio)) { $Total_Count++ }
+    if (-Not (Test-Path $SampleImage)) { $Total_Count++ }
+    if (-Not (Test-Path $SampleSubs)) { $Total_Count++ }
+
+    if (-Not (Test-Path $SampleVideo)) {
+        $Start_Time = Get-Date
+        $Current_Count++
+        & "$Workspace\ffmpeg.exe" -hide_banner -y -f lavfi -i "testsrc=duration=10:size=1280x720:rate=30" -c:v libx264 -crf 23 "$SampleVideo" 2>&1 | Out-Null
+        $elapsed = (New-TimeSpan -Start $Start_Time -End (Get-Date)).TotalSeconds.ToString('0')
+        text_with_padding "     $ICON_PASS Sample video" "[${elapsed}s]"
     }
-    else {
-        $End_Time = Get-Date
-        text_with_padding "❌ ${name} test failed" "[ $((New-TimeSpan -Start $Start_Time -End $End_Time).Seconds)s ]" 1               
-        $script:FAILED_TESTS++
+
+    if (-Not (Test-Path $SampleAudio)) {
+        $Start_Time = Get-Date
+        $Current_Count++
+        & "$Workspace\ffmpeg.exe" -hide_banner -y -f lavfi -i "sine=frequency=1000:duration=10" -c:a pcm_s16le "$SampleAudio" 2>&1 | Out-Null
+        $elapsed = (New-TimeSpan -Start $Start_Time -End (Get-Date)).TotalSeconds.ToString('0')
+        text_with_padding "     $ICON_PASS Sample audio" "[${elapsed}s]"
+    }
+
+    if (-Not (Test-Path $SampleImage)) {
+        $Start_Time = Get-Date
+        $Current_Count++
+        & "$Workspace\ffmpeg.exe" -hide_banner -y -f lavfi -i "testsrc=duration=1:size=640x480:rate=1" -frames:v 1 "$SampleImage" 2>&1 | Out-Null
+        $elapsed = (New-TimeSpan -Start $Start_Time -End (Get-Date)).TotalSeconds.ToString('0')
+        text_with_padding "     $ICON_PASS Sample image" "[${elapsed}s]"
+    }
+
+    if (-Not (Test-Path $SampleSubs)) {
+        $Current_Count++
+        $assContent = @(
+            '[Script Info]'
+            'Title: Test Subtitle'
+            'ScriptType: v4.00+'
+            ''
+            '[V4+ Styles]'
+            'Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding'
+            'Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,10,0'
+            ''
+            '[Events]'
+            'Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text'
+            'Dialogue: 0,0:00:01.00,0:00:05.00,Default,,0,0,0,,Test subtitle'
+        ) -join "`n"
+        [System.IO.File]::WriteAllText($SampleSubs, $assContent)
+        text_with_padding "     $ICON_PASS Sample subtitles" "[0s]"
+    }
+
+    if ($Current_Count -gt 0) {
+        Write-Host ([string]::new('-', $TOTAL_WIDTH_TEXT))
     }
 }
 
-# Main execution
+function run_test {
+    param ($name, $command, $expected_output)
+
+    $script:TOTAL++
+    $name = $name.ToUpper()
+    $num = $script:TOTAL.ToString().PadLeft(2)
+    $Start_Time = Get-Date
+    $test_output = Invoke-Expression "$Workspace\ffmpeg.exe $command 2>&1" | Out-String
+    $End_Time = Get-Date
+    $elapsed = "$((New-TimeSpan -Start $Start_Time -End $End_Time).Seconds)s"
+    if ( $test_output -cmatch $expected_output ) {
+        text_with_padding " ${num}. $ICON_PASS ${name}" "[ ${elapsed} ]"
+        $script:PASSED++
+    }
+    else {
+        text_with_padding " ${num}. $ICON_FAIL ${name}" "[ ${elapsed} ]"
+        $script:FAILED++
+    }
+}
+
+function check_compiled {
+    param ($name, $type, $symbol)
+
+    $script:TOTAL++
+    $name = $name.ToUpper()
+    $num = $script:TOTAL.ToString().PadLeft(2)
+
+    $list_output = Invoke-Expression "$Workspace\ffmpeg.exe -hide_banner -${type} 2>&1" | Out-String
+    if ($list_output -match $symbol) {
+        text_with_padding " ${num}. $ICON_PASS ${name}" "[compiled]"
+        $script:PASSED++
+    }
+    else {
+        text_with_padding " ${num}. $ICON_FAIL ${name}" "[missing]"
+        $script:FAILED++
+    }
+}
+
+# ==============================================================
 Write-Host ([string]::new('-', $TOTAL_WIDTH_TEXT))
-Write-Host "        _   _       __  __                      "
-Write-Host "       | \ | | ___ |  \/  | ___ _ __ ___ _   _  "
-Write-Host "       |  \| |/ _ \| |\/| |/ _ \ '__/ __| | | | "
-Write-Host "       | |\  | (_) | |  | |  __/ | | (__| |_| | "
-Write-Host "       |_| \_|\___/|_|  |_|\___|_|  \___|\__, | "
-Write-Host "         _____ _____ __  __ ____  _____ _|___/  "
-Write-Host "        |  ___|  ___|  \/  |  _ \| ____/ ___|   "
-Write-Host "        | |_  | |_  | |\/| | |_) |  _|| |  _    "
-Write-Host "        |  _| |  _| | |  | |  __/| |__| |_| |   "
-Write-Host "        |_|   |_|   |_|  |_|_|   |_____\____|   "
-Write-Host ""
+Write-Host '  NoMercy FFmpeg Test Suite'
 Write-Host ([string]::new('-', $TOTAL_WIDTH_TEXT))
 
 check_command
 generate_samples
 
-# Basic tests
-run_test "version" "-version" "ffmpeg version"
+Write-Host ([string]::new('-', $TOTAL_WIDTH_TEXT))
 
-# Video codecs
+run_test "version" "-version" "ffmpeg version"
 run_test "libx264" "-y -i $SampleVideo -c:v libx264 $TestRoot\test_h264.mp4" "x264"
 run_test "libx265" "-y -i $SampleVideo -c:v libx265 $TestRoot\test_h265.mp4" "x265"
-run_test "libvpx" "-y -i $SampleVideo -c:v libvpx-vp9 $TestRoot\test_vp9.webm" "vp9"
-run_test "libaom" "-y -i $SampleVideo -c:v libaom-av1 $TestRoot\test_av1.mkv" "av1"
-run_test "libtheora" "-y -i $SampleVideo -c:v libtheora $TestRoot\test_theora.ogv" "theora"
-
-# Audio codecs
+run_test "libvpx" "-y -i $SampleVideo -c:v libvpx-vp9 -frames:v 1 $TestRoot\test_vp9.webm" "vp9"
+run_test "libaom" "-y -i $SampleVideo -c:v libaom-av1 -frames:v 1 $TestRoot\test_av1.mkv" "av1"
+run_test "libtheora" "-y -i $SampleVideo -c:v libtheora -frames:v 1 $TestRoot\test_theora.ogv" "theora"
 run_test "libfdk_aac" "-y -i $SampleAudio -c:a libfdk_aac $TestRoot\test_aac.m4a" "aac"
 run_test "libopus" "-y -i $SampleAudio -c:a libopus $TestRoot\test_opus.opus" "opus"
 run_test "libmp3lame" "-y -i $SampleAudio -c:a libmp3lame $TestRoot\test_mp3.mp3" "mp3"
-
-# Image codecs
-run_test "libwebp" "-y -i $SampleImage -c:v libwebp $TestRoot\test_webp.webp" "webp"
+run_test "libwebp" "-y -i $SampleImage -c:v libwebp -f webp $TestRoot\test_webp.webp" "webp"
 run_test "libopenjpeg" "-y -i $SampleImage -c:v libopenjpeg $TestRoot\test_jp2.jp2" "openjpeg"
-
-# Subtitle codecs
-run_test "libass" "-y -i $SampleVideo -vf `"ass=$SampleSubs`" $TestRoot\test_ass.mp4" "ass"
-run_test "vobsub_muxer" "-hide_banner -muxers" "vobsub"
-run_test "spritevtt_muxer" "-hide_banner -muxers" "spritevtt"
-run_test "chapters_vtt_muxer" "-hide_banner -muxers" "chapters_vtt"
-
-# Auto-create directories
+run_test "libass" "-y -i $SampleVideo -vf ass=$($SampleSubs.Replace('\','/')) $TestRoot\test_ass.mp4" "ass"
 run_test "auto_mkdir" "-y -f lavfi -i `"testsrc=duration=1:size=320x240:rate=1`" -frames:v 1 $TestRoot\subdir_test\nested\output.png" "output.png"
 
-# Hardware acceleration (may fail if no hardware support)
-run_test "NVENC" "-y -i $SampleVideo -c:v h264_nvenc $TestRoot\test_nvenc.mp4" "nvenc"
-run_test "VPL" "-y -i $SampleVideo -c:v h264_vpl $TestRoot\test_vpl.mp4" "vpl"
-run_test "AMF" "-y -i $SampleVideo -c:v h264_amf $TestRoot\test_amf.mp4" "amf"
-
-# Additional format tests
-run_test "libbluray" "-hide_banner -protocols | findstr bluray" "bluray"
-run_test "libdvdread" "-hide_banner -version | findstr dvdread" "dvdread"
-run_test "libcdio" "-hide_banner -version | findstr cdio" "cdio"
-run_test "libfribidi" "-hide_banner -version | findstr fribidi" "fribidi"
-run_test "libsrt" "-hide_banner -version | findstr srt" "srt"
-run_test "libxml2" "-hide_banner -version | findstr xml" "xml"
-
-# AV1 codec tests
-run_test "libdav1d" "-hide_banner -decoders" "dav1d"
-run_test "librav1e" "-hide_banner -encoders" "rav1e"
-
-# OCR subtitle encoder
-run_test "ocr_subtitle" "-hide_banner -encoders" "ocr_subtitle"
-
-# Print summary
 Write-Host ([string]::new('-', $TOTAL_WIDTH_TEXT))
-text_with_padding "📊 Summary:" ""
-text_with_padding "Total tests:" "$script:TOTAL_TESTS"
-text_with_padding "Passed tests:" "$script:PASSED_TESTS"
-text_with_padding "Failed tests:" "$script:FAILED_TESTS"
+
+check_compiled "vobsub muxer" "muxers" "vobsub"
+check_compiled "spritevtt muxer" "muxers" "spritevtt"
+check_compiled "chapter_vtt muxer" "muxers" "chapters_vtt"
+check_compiled "ocr_subtitle encoder" "encoders" "ocr_subtitle"
+check_compiled "libbluray" "protocols" "bluray"
+check_compiled "libfribidi" "version" "fribidi"
+check_compiled "libsrt" "version" "srt"
+check_compiled "libxml2" "version" "xml"
+check_compiled "libdav1d" "decoders" "dav1d"
+check_compiled "librav1e" "encoders" "rav1e"
+check_compiled "nvenc" "encoders" "h264_nvenc"
+check_compiled "amf" "encoders" "h264_amf"
+
+Write-Host ([string]::new('-', $TOTAL_WIDTH_TEXT))
+text_with_padding " Results:" "$script:PASSED/$script:TOTAL passed"
+if ($script:FAILED -gt 0) {
+    text_with_padding " $ICON_FAIL FAILED:" "$script:FAILED"
+}
 Write-Host ([string]::new('-', $TOTAL_WIDTH_TEXT))
 Write-Host ""
 
-# Cleanup
 Remove-Item -Recurse -Force -Path $TestRoot -ErrorAction SilentlyContinue
 
-# Exit with failure if any tests failed
-if ($FAILED_TESTS -gt 0) {
-    exit $FAILED_TESTS
-}
+if ($script:FAILED -gt 0) { exit 1 }
 exit 0

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -13,9 +13,9 @@ if [[ -L "$Workspace" ]]; then
 fi
 
 TOTAL_WIDTH_TEXT=54
-TOTAL_TESTS=0
-PASSED_TESTS=0
-FAILED_TESTS=0
+TOTAL=0
+PASSED=0
+FAILED=0
 
 TestRoot="${Workspace}/test_files"
 SampleVideo="${TestRoot}/sample.mp4"
@@ -23,125 +23,25 @@ SampleAudio="${TestRoot}/sample.wav"
 SampleImage="${TestRoot}/sample.png"
 SampleSubs="${TestRoot}/test.ass"
 
-# Cleanup and create test directory
 rm -rf "${TestRoot}"
 mkdir -p "${TestRoot}"
 
-get_test_runs_count() {
-    local searchString="$1"
-    local filePath="$0"
-    local fileContent
-    local matches
-    local m_count
-    fileContent=$(<"$filePath")
-    _matches=$(grep -o "$searchString" <<<"$fileContent")
-    matches_count=$(echo "$_matches" | wc -l)
-    if [ "$matches_count" -gt 0 ]; then
-        matches_count=$((matches_count - 1))
-    fi
-    echo "$matches_count"
+line() {
+    local left="$1" right="$2"
+    local left_len=$(printf '%s' "$left" | wc -m)
+    local right_len=$(printf '%s' "$right" | wc -m)
+    local gap=$((TOTAL_WIDTH_TEXT - left_len - right_len))
+    [ $gap -lt 1 ] && gap=1
+    printf "%s%*s%s\n" "$left" "$gap" "" "$right"
 }
 
-TOTAL_RUNS=$(get_test_runs_count 'run_test "')
-
-generate_samples() {
-    local Total_Count=0
-    local Current_Count=0
-    local Start_Time End_Time
-
-    # Count needed samples
-    [[ ! -f "$SampleVideo" ]] && ((Total_Count++))
-    [[ ! -f "$SampleAudio" ]] && ((Total_Count++))
-    [[ ! -f "$SampleImage" ]] && ((Total_Count++))
-    [[ ! -f "$SampleSubs" ]] && ((Total_Count++))
-
-    # Generate samples
-    if [[ ! -f "$SampleVideo" ]]; then
-        Start_Time=$(date +%s)
-        Current_Count=$((Current_Count + 1))
-        text_with_padding "📹 Generating sample video" "[$Current_Count/$Total_Count]" 1
-        ffmpeg_command="-hide_banner -y -f lavfi -i \"testsrc=duration=10:size=1280x720:rate=30\" -c:v libx264 -crf 23 \"$SampleVideo\""
-        output=$(eval "${Workspace}/ffmpeg $ffmpeg_command" 2>&1)
-        exit_code=$?
-        End_Time=$(date +%s)
-        if [[ $exit_code -ne 0 ]]; then
-            text_with_padding "❌ Error generating sample video" "[$((End_Time - Start_Time))s]" 1
-            echo "$output"
-            exit 1
-        fi
-        text_with_padding "✅ Sample video generated" "[$((End_Time - Start_Time))s]" 1
-    fi
-
-    if [[ ! -f "$SampleAudio" ]]; then
-        Start_Time=$(date +%s)
-        Current_Count=$((Current_Count + 1))
-        text_with_padding "🔊 Generating sample audio" "[$Current_Count/$Total_Count]" 1
-        ffmpeg_command="-hide_banner -y -f lavfi -i \"sine=frequency=1000:duration=10\" -c:a pcm_s16le \"$SampleAudio\""
-        output=$(eval "${Workspace}/ffmpeg $ffmpeg_command" 2>&1)
-        exit_code=$?
-        End_Time=$(date +%s)
-        if [[ $exit_code -ne 0 ]]; then
-            text_with_padding "❌ Error generating sample audio" "[$((End_Time - Start_Time))s]" 1
-            echo "$output"
-            exit 1
-        fi
-        text_with_padding "✅ Sample audio generated" "[$((End_Time - Start_Time))s]" 1
-    fi
-
-    if [[ ! -f "$SampleImage" ]]; then
-        Start_Time=$(date +%s)
-        Current_Count=$((Current_Count + 1))
-        text_with_padding "🖼️ Generating sample image" "[$Current_Count/$Total_Count]"
-        ffmpeg_command="-hide_banner -y -f lavfi -i \"testsrc=duration=1:size=640x480:rate=1\" -frames:v 1 \"$SampleImage\""
-        output=$(eval "${Workspace}/ffmpeg $ffmpeg_command" 2>&1)
-        exit_code=$?
-        End_Time=$(date +%s)
-        if [[ $exit_code -ne 0 ]]; then
-            text_with_padding "❌ Error generating sample image" "[$((End_Time - Start_Time))s]" 1
-            echo "$output"
-            exit 1
-        fi
-        text_with_padding "✅ Sample image generated" "[$((End_Time - Start_Time))s]" 1
-    fi
-
-    if [[ ! -f "$SampleSubs" ]]; then
-        Start_Time=$(date +%s)
-        Current_Count=$((Current_Count + 1))
-        text_with_padding "📝 Generating sample subtitles" "[$Current_Count/$Total_Count]" 1
-        {
-            echo -e "[Script Info]"
-            echo -e "Title: Test Subtitle"
-            echo -e "ScriptType: v4.00+"
-            echo -e ""
-            echo -e "[V4+ Styles]"
-            echo -e "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding"
-            echo -e "Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,10,0"
-            echo -e ""
-            echo -e "[Events]"
-            echo -e "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
-            echo -e "Dialogue: 0,0:00:01.00,0:00:05.00,Default,,0,0,0,,Test subtitle"
-        } >$SampleSubs
-        End_Time=$(date +%s)
-        text_with_padding "✅ Sample subtitles generated" "[$((End_Time - Start_Time))s]" 1
-    fi
-
-    if [ $Total_Count -gt 0 ]; then
-        printf "%${TOTAL_WIDTH_TEXT}s\n" | tr ' ' '-' # Print a horizontal line
-    fi
-}
-
-text_with_padding() {
-    local text_before=$1
-    local text_after=$2
-    local extra_padding=${3:-0}
-    local text_length=$((${#text_before} + ${#text_after}))
-    local padding=$((TOTAL_WIDTH_TEXT - text_length - extra_padding))
-    printf "%s%*s%s\n" "$text_before" "$padding" " " "$text_after"
+hr() {
+    printf '%54s\n' | tr ' ' '-'
 }
 
 check_command() {
     if [[ ! -f ${Workspace}/ffmpeg ]]; then
-        printf "%s\n" "❌ FFmpeg executable not found in current directory"
+        printf "%s\n" "x FFmpeg executable not found in current directory"
         exit 1
     fi
     if [[ ! -x ${Workspace}/ffmpeg ]]; then
@@ -149,112 +49,151 @@ check_command() {
     fi
 }
 
-run_test() {
-    local name=$1
-    local command=$2
-    local expected_output=$3
-    local test_output
-    local exit_code
+generate_samples() {
+    local Total_Count=0
+    local Current_Count=0
+    local Start_Time End_Time
 
-    TOTAL_TESTS=$((TOTAL_TESTS + 1))
-    name=$(echo $name | tr '[:lower:]' '[:upper:]')
+    [[ ! -f "$SampleVideo" ]] && ((Total_Count++))
+    [[ ! -f "$SampleAudio" ]] && ((Total_Count++))
+    [[ ! -f "$SampleImage" ]] && ((Total_Count++))
+    [[ ! -f "$SampleSubs" ]] && ((Total_Count++))
 
-    text_with_padding "🧪 Testing ${name}" "[${TOTAL_TESTS}/${TOTAL_RUNS}]" 1
-    Start_Time=$(date +%s)
+    if [[ ! -f "$SampleVideo" ]]; then
+        Start_Time=$(date +%s)
+        output=$(eval "${Workspace}/ffmpeg -hide_banner -y -f lavfi -i \"testsrc=duration=10:size=1280x720:rate=30\" -c:v libx264 -crf 23 \"$SampleVideo\"" 2>&1)
+        if [[ $? -ne 0 ]]; then line "     x Sample video" "[FAIL]"; echo "$output"; exit 1; fi
+        line "     + Sample video" "[$(($(date +%s) - Start_Time))s]"
+    fi
 
-    test_output=$(eval "${Workspace}/ffmpeg $command" 2>&1)
-    exit_code=$?
-    if [[ $exit_code -eq 0 ]] && echo "$test_output" | grep -q "$expected_output"; then
-        End_Time=$(date +%s)
-        text_with_padding "✅ ${name} test passed" "[$((End_Time - Start_Time))s]" 1
-        PASSED_TESTS=$((PASSED_TESTS + 1))
-    else
-        End_Time=$(date +%s)
-        text_with_padding "❌ ${name} test failed" "[$((End_Time - Start_Time))s]" 1
-        FAILED_TESTS=$((FAILED_TESTS + 1))
+    if [[ ! -f "$SampleAudio" ]]; then
+        Start_Time=$(date +%s)
+        output=$(eval "${Workspace}/ffmpeg -hide_banner -y -f lavfi -i \"sine=frequency=1000:duration=10\" -c:a pcm_s16le \"$SampleAudio\"" 2>&1)
+        if [[ $? -ne 0 ]]; then line "     x Sample audio" "[FAIL]"; echo "$output"; exit 1; fi
+        line "     + Sample audio" "[$(($(date +%s) - Start_Time))s]"
+    fi
+
+    if [[ ! -f "$SampleImage" ]]; then
+        Start_Time=$(date +%s)
+        output=$(eval "${Workspace}/ffmpeg -hide_banner -y -f lavfi -i \"testsrc=duration=1:size=640x480:rate=1\" -frames:v 1 \"$SampleImage\"" 2>&1)
+        if [[ $? -ne 0 ]]; then line "     x Sample image" "[FAIL]"; echo "$output"; exit 1; fi
+        line "     + Sample image" "[$(($(date +%s) - Start_Time))s]"
+    fi
+
+    if [[ ! -f "$SampleSubs" ]]; then
+        {
+            echo "[Script Info]"
+            echo "Title: Test Subtitle"
+            echo "ScriptType: v4.00+"
+            echo ""
+            echo "[V4+ Styles]"
+            echo "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding"
+            echo "Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,10,0"
+            echo ""
+            echo "[Events]"
+            echo "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
+            echo "Dialogue: 0,0:00:01.00,0:00:05.00,Default,,0,0,0,,Test subtitle"
+        } >$SampleSubs
+        line "     + Sample subtitles" "[0s]"
     fi
 }
 
-# Main execution
-printf "%${TOTAL_WIDTH_TEXT}s\n" | tr ' ' '-' # Print a horizontal line
-printf "%s\n" "        _   _       __  __                      "
-printf "%s\n" "       | \ | | ___ |  \/  | ___ _ __ ___ _   _  "
-printf "%s\n" "       |  \| |/ _ \| |\/| |/ _ \ '__/ __| | | | "
-printf "%s\n" "       | |\  | (_) | |  | |  __/ | | (__| |_| | "
-printf "%s\n" "       |_| \_|\___/|_|  |_|\___|_|  \___|\__, | "
-printf "%s\n" "         _____ _____ __  __ ____  _____ _|___/  "
-printf "%s\n" "        |  ___|  ___|  \/  |  _ \| ____/ ___|   "
-printf "%s\n" "        | |_  | |_  | |\/| | |_) |  _|| |  _    "
-printf "%s\n" "        |  _| |  _| | |  | |  __/| |__| |_| |   "
-printf "%s\n" "        |_|   |_|   |_|  |_|_|   |_____\____|   "
-printf "%s\n" ""
-printf "%${TOTAL_WIDTH_TEXT}s\n" | tr ' ' '-' # Print a horizontal line
+run_test() {
+    local name=$1 command=$2 expected_output=$3
+    TOTAL=$((TOTAL + 1))
+    name=$(echo $name | tr '[:lower:]' '[:upper:]')
+    local num=$(printf "%2d" $TOTAL)
+    local Start_Time=$(date +%s)
+
+    test_output=$(eval "${Workspace}/ffmpeg $command" 2>&1)
+    exit_code=$?
+    local elapsed="$(($(date +%s) - Start_Time))s"
+
+    if [[ $exit_code -eq 0 ]] && echo "$test_output" | grep -q "$expected_output"; then
+        line " ${num}. + ${name}" "[${elapsed}]"
+        PASSED=$((PASSED + 1))
+    else
+        line " ${num}. x ${name}" "[${elapsed}]"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+check_compiled() {
+    local name=$1 type=$2 symbol=$3
+    TOTAL=$((TOTAL + 1))
+    name=$(echo $name | tr '[:lower:]' '[:upper:]')
+    local num=$(printf "%2d" $TOTAL)
+
+    local list_output
+    list_output=$(eval "${Workspace}/ffmpeg -hide_banner -${type}" 2>&1)
+
+    if echo "$list_output" | grep -q "$symbol"; then
+        line " ${num}. + ${name}" "[compiled]"
+        PASSED=$((PASSED + 1))
+    else
+        line " ${num}. x ${name}" "[missing]"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+# ==============================================================
+hr
+printf "%s\n" "  NoMercy FFmpeg Test Suite"
+hr
 
 check_command
 generate_samples
+hr
 
-# Basic tests
 run_test "version" "-version" "ffmpeg version"
-
-# Video codecs
 run_test "libx264" "-y -i ${SampleVideo} -c:v libx264 ${TestRoot}/test_h264.mp4" "x264"
 run_test "libx265" "-y -i ${SampleVideo} -c:v libx265 ${TestRoot}/test_h265.mp4" "x265"
-run_test "libvpx" "-y -i ${SampleVideo} -c:v libvpx-vp9 ${TestRoot}/test_vp9.webm" "vp9"
-run_test "libaom" "-y -i ${SampleVideo} -c:v libaom-av1 ${TestRoot}/test_av1.mkv" "av1"
-run_test "libtheora" "-y -i ${SampleVideo} -c:v libtheora ${TestRoot}/test_theora.ogv" "theora"
-
-# Audio codecs
+run_test "libvpx" "-y -i ${SampleVideo} -c:v libvpx-vp9 -frames:v 1 ${TestRoot}/test_vp9.webm" "vp9"
+run_test "libaom" "-y -i ${SampleVideo} -c:v libaom-av1 -frames:v 1 ${TestRoot}/test_av1.mkv" "av1"
+run_test "libtheora" "-y -i ${SampleVideo} -c:v libtheora -frames:v 1 ${TestRoot}/test_theora.ogv" "theora"
 run_test "libfdk_aac" "-y -i ${SampleAudio} -c:a libfdk_aac ${TestRoot}/test_aac.m4a" "aac"
 run_test "libopus" "-y -i ${SampleAudio} -c:a libopus ${TestRoot}/test_opus.opus" "opus"
 run_test "libmp3lame" "-y -i ${SampleAudio} -c:a libmp3lame ${TestRoot}/test_mp3.mp3" "mp3"
-
-# Image codecs
-run_test "libwebp" "-y -i ${SampleImage} -c:v libwebp ${TestRoot}/test_webp.webp" "webp"
+run_test "libwebp" "-y -i ${SampleImage} -c:v libwebp -f webp ${TestRoot}/test_webp.webp" "webp"
 run_test "libopenjpeg" "-y -i ${SampleImage} -c:v libopenjpeg ${TestRoot}/test_jp2.jp2" "openjpeg"
-
-# Subtitle codecs
 run_test "libass" "-y -i ${SampleVideo} -vf \"ass=${SampleSubs}\" ${TestRoot}/test_ass.mp4" "ass"
-run_test "vobsub_muxer" "-hide_banner -muxers" "vobsub"
-run_test "spritevtt_muxer" "-hide_banner -muxers" "spritevtt"
-run_test "chapters_vtt_muxer" "-hide_banner -muxers" "chapters_vtt"
-
-# Auto-create directories
 run_test "auto_mkdir" "-y -f lavfi -i \"testsrc=duration=1:size=320x240:rate=1\" -frames:v 1 ${TestRoot}/subdir_test/nested/output.png" "output.png"
 
-# Hardware acceleration (may fail if no hardware support)
-run_test "NVENC" "-y -i ${SampleVideo} -c:v h264_nvenc ${TestRoot}/test_nvenc.mp4" "nvenc"
-run_test "VPL" "-y -i ${SampleVideo} -c:v h264_vpl ${TestRoot}/test_vpl.mp4" "vpl"
-run_test "AMF" "-y -i ${SampleVideo} -c:v h264_amf ${TestRoot}/test_amf.mp4" "amf"
+hr
 
-# Additional format tests
-run_test "libbluray" "-hide_banner -protocols | grep bluray" "bluray"
-run_test "libdvdread" "-hide_banner -version | grep dvdread" "dvdread"
-run_test "libcdio" "-hide_banner -version | grep cdio" "cdio"
-run_test "libfribidi" "-hide_banner -version | grep fribidi" "fribidi"
-run_test "libsrt" "-hide_banner -version | grep srt" "srt"
-run_test "libxml2" "-hide_banner -version | grep xml" "xml"
+check_compiled "vobsub muxer" "muxers" "vobsub"
+check_compiled "spritevtt muxer" "muxers" "spritevtt"
+check_compiled "chapter_vtt muxer" "muxers" "chapters_vtt"
+check_compiled "ocr_subtitle encoder" "encoders" "ocr_subtitle"
+check_compiled "libbluray" "protocols" "bluray"
+check_compiled "libfribidi" "version" "fribidi"
+check_compiled "libsrt" "version" "srt"
+check_compiled "libxml2" "version" "xml"
+check_compiled "libdav1d" "decoders" "dav1d"
+check_compiled "librav1e" "encoders" "rav1e"
 
-# AV1 codec tests
-run_test "libdav1d" "-hide_banner -decoders" "dav1d"
-run_test "librav1e" "-hide_banner -encoders" "rav1e"
+OS_TYPE="$(uname -s)"
+case "$OS_TYPE" in
+    Darwin)
+        check_compiled "videotoolbox h264" "encoders" "h264_videotoolbox"
+        check_compiled "videotoolbox hevc" "encoders" "hevc_videotoolbox"
+        ;;
+    Linux)
+        check_compiled "nvenc" "encoders" "h264_nvenc"
+        check_compiled "vaapi" "encoders" "h264_vaapi"
+        ;;
+esac
+check_compiled "amf" "encoders" "h264_amf"
 
-# OCR subtitle encoder
-run_test "ocr_subtitle" "-hide_banner -encoders" "ocr_subtitle"
-
-# Print summary
-printf "%${TOTAL_WIDTH_TEXT}s\n" | tr ' ' '-' # Print a horizontal line
-text_with_padding "📊 Summary:" ""
-text_with_padding "Total tests:" "${TOTAL_TESTS}"
-text_with_padding "Passed tests:" "${PASSED_TESTS}"
-text_with_padding "Failed tests:" "${FAILED_TESTS}"
-printf "%${TOTAL_WIDTH_TEXT}s\n" | tr ' ' '-' # Print a horizontal line
+hr
+line " Results:" "${PASSED}/${TOTAL} passed"
+if [ ${FAILED} -gt 0 ]; then
+    line " FAILED:" "${FAILED}"
+fi
+hr
 echo ""
 
-# cleanup
 rm -rf "${TestRoot}"
 
-# Exit with failure if any tests failed
-if [ "${FAILED_TESTS}" -gt 0 ]; then
-    exit $FAILED_TESTS
-fi
+if [ "${FAILED}" -gt 0 ]; then exit 1; fi
 exit 0


### PR DESCRIPTION
## Summary
- Per-script Docker layer caching for all 5 platforms
- Individual COPY per file, right before the script that uses it
- spritevtt no longer steals .webp/.png extensions
- auto-create-dirs fix for FFmpeg 8.0
- Deterministic test suite (no hardware dependency)
- CI stops destroying buildx cache between runs
- Fast test encodes (-frames:v 1)

## DO NOT MERGE — testing CI builds first
Verify all 5 platforms build and test successfully before merging.