### PR TITLE
fix: bump FFmpeg 8.0 -> 8.1 for CVE-2026-40962

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,9 +157,9 @@ jobs:
             echo "🚀 Exporting $platform..."
             if docker pull nomercyentertainment/ffmpeg-${platform}:latest; then
               docker create --name ${platform}-container nomercyentertainment/ffmpeg-${platform}:latest
-              if docker cp ${platform}-container:/build/ffmpeg-8.0-${platform}.${platforms[$platform]} downloads/ffmpeg-8.0-${platform}.${platforms[$platform]}; then
+              if docker cp ${platform}-container:/build/ffmpeg-8.1-${platform}.${platforms[$platform]} downloads/ffmpeg-8.1-${platform}.${platforms[$platform]}; then
                 echo "✅ Successfully exported $platform"
-                ls -lh downloads/ffmpeg-8.0-${platform}.${platforms[$platform]}
+                ls -lh downloads/ffmpeg-8.1-${platform}.${platforms[$platform]}
               else
                 echo "⚠️ Artifact not found for $platform"
               fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,57 +129,57 @@ jobs:
       # Upload platform-specific release assets
       - name: Upload Linux x86_64 Asset
         uses: actions/upload-release-asset@v1
-        if: hashFiles('downloads/ffmpeg-8.0-linux-x86_64.tar.gz') != ''
+        if: hashFiles('downloads/ffmpeg-8.1-linux-x86_64.tar.gz') != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: downloads/ffmpeg-8.0-linux-x86_64.tar.gz
-          asset_name: ffmpeg-8.0-linux-x86_64-${{ needs.check-prerequisites.outputs.version }}.tar.gz
+          asset_path: downloads/ffmpeg-8.1-linux-x86_64.tar.gz
+          asset_name: ffmpeg-8.1-linux-x86_64-${{ needs.check-prerequisites.outputs.version }}.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload Linux Aarch64 Asset
         uses: actions/upload-release-asset@v1
-        if: hashFiles('downloads/ffmpeg-8.0-linux-aarch64.tar.gz') != ''
+        if: hashFiles('downloads/ffmpeg-8.1-linux-aarch64.tar.gz') != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: downloads/ffmpeg-8.0-linux-aarch64.tar.gz
-          asset_name: ffmpeg-8.0-linux-aarch64-${{ needs.check-prerequisites.outputs.version }}.tar.gz
+          asset_path: downloads/ffmpeg-8.1-linux-aarch64.tar.gz
+          asset_name: ffmpeg-8.1-linux-aarch64-${{ needs.check-prerequisites.outputs.version }}.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload Windows x86_64 Asset
         uses: actions/upload-release-asset@v1
-        if: hashFiles('downloads/ffmpeg-8.0-windows-x86_64.zip') != ''
+        if: hashFiles('downloads/ffmpeg-8.1-windows-x86_64.zip') != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: downloads/ffmpeg-8.0-windows-x86_64.zip
-          asset_name: ffmpeg-8.0-windows-x86_64-${{ needs.check-prerequisites.outputs.version }}.zip
+          asset_path: downloads/ffmpeg-8.1-windows-x86_64.zip
+          asset_name: ffmpeg-8.1-windows-x86_64-${{ needs.check-prerequisites.outputs.version }}.zip
           asset_content_type: application/zip
 
       - name: Upload Darwin x86_64 Asset
         uses: actions/upload-release-asset@v1
-        if: hashFiles('downloads/ffmpeg-8.0-darwin-x86_64.tar.gz') != ''
+        if: hashFiles('downloads/ffmpeg-8.1-darwin-x86_64.tar.gz') != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: downloads/ffmpeg-8.0-darwin-x86_64.tar.gz
-          asset_name: ffmpeg-8.0-darwin-x86_64-${{ needs.check-prerequisites.outputs.version }}.tar.gz
+          asset_path: downloads/ffmpeg-8.1-darwin-x86_64.tar.gz
+          asset_name: ffmpeg-8.1-darwin-x86_64-${{ needs.check-prerequisites.outputs.version }}.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload Darwin ARM64 Asset
         uses: actions/upload-release-asset@v1
-        if: hashFiles('downloads/ffmpeg-8.0-darwin-arm64.tar.gz') != ''
+        if: hashFiles('downloads/ffmpeg-8.1-darwin-arm64.tar.gz') != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: downloads/ffmpeg-8.0-darwin-arm64.tar.gz
-          asset_name: ffmpeg-8.0-darwin-arm64-${{ needs.check-prerequisites.outputs.version }}.tar.gz
+          asset_path: downloads/ffmpeg-8.1-darwin-arm64.tar.gz
+          asset_name: ffmpeg-8.1-darwin-arm64-${{ needs.check-prerequisites.outputs.version }}.tar.gz
           asset_content_type: application/gzip
 
       # Notify relevant services (could be Slack, Discord, etc.)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,9 +81,9 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.platform }}" == "linux" ] && [ "${{ matrix.arch }}" == "aarch64" ]; then
-            FILE_NAME="downloads/ffmpeg-8.0-linux-aarch64.tar.gz"
+            FILE_NAME="downloads/ffmpeg-8.1-linux-aarch64.tar.gz"
           else
-            FILE_NAME="downloads/ffmpeg-8.0-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz"
+            FILE_NAME="downloads/ffmpeg-8.1-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz"
           fi
           
           echo "Looking for file: $FILE_NAME"
@@ -109,7 +109,7 @@ jobs:
         if: matrix.platform == 'windows'
         shell: bash
         run: |
-          FILE_NAME="downloads/ffmpeg-8.0-windows-${{ matrix.arch }}.zip"
+          FILE_NAME="downloads/ffmpeg-8.1-windows-${{ matrix.arch }}.zip"
           echo "Looking for file: $FILE_NAME"
           if [ -f "$FILE_NAME" ]; then
             echo "Found $FILE_NAME, extracting..."

--- a/ffmpeg-base.dockerfile
+++ b/ffmpeg-base.dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     NVIDIA_VISIBLE_DEVICES=all \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
-ENV ffmpeg_version=8.1 \
+ENV ffmpeg_version=8.0 \
     iconv_version=1.18 \
     libxml2_version=2.13 \
     zlib_version=1.3.1 \
@@ -724,6 +724,12 @@ RUN \
     && git clone --branch release https://code.videolan.org/videolan/libplacebo.git libplacebo >/dev/null 2>&1 \
     && echo "✅ Download completed successfully" \
     && echo "------------------------------------------------------"
+
+# FFmpeg version is overridden late so that bumping it only invalidates
+# the FFmpeg fetch+build layers — all dependency compile layers above
+# stay cached. The earlier ENV must be left byte-identical to historical
+# values so the registry buildcache hash still matches.
+ENV ffmpeg_version=8.1
 
 # Download ffmpeg
 RUN \

--- a/ffmpeg-base.dockerfile
+++ b/ffmpeg-base.dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     NVIDIA_VISIBLE_DEVICES=all \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
-ENV ffmpeg_version=8.0 \
+ENV ffmpeg_version=8.1 \
     iconv_version=1.18 \
     libxml2_version=2.13 \
     zlib_version=1.3.1 \

--- a/ffmpeg-darwin-arm64.dockerfile
+++ b/ffmpeg-darwin-arm64.dockerfile
@@ -416,6 +416,6 @@ RUN chmod +x /scripts/init/package.sh && /scripts/init/package.sh
 
 FROM alpine:latest AS final
 
-COPY --from=darwin /output/ffmpeg-8.0-darwin-arm64.tar.gz /build/ffmpeg-8.0-darwin-arm64.tar.gz
+COPY --from=darwin /output/ffmpeg-8.1-darwin-arm64.tar.gz /build/ffmpeg-8.1-darwin-arm64.tar.gz
 
-CMD ["cp", "/build/ffmpeg-8.0-darwin-arm64.tar.gz", "/output"]
+CMD ["cp", "/build/ffmpeg-8.1-darwin-arm64.tar.gz", "/output"]

--- a/ffmpeg-darwin-x86_64.dockerfile
+++ b/ffmpeg-darwin-x86_64.dockerfile
@@ -416,6 +416,6 @@ RUN chmod +x /scripts/init/package.sh && /scripts/init/package.sh
 
 FROM alpine:latest AS final
 
-COPY --from=darwin /output/ffmpeg-8.0-darwin-x86_64.tar.gz /build/ffmpeg-8.0-darwin-x86_64.tar.gz
+COPY --from=darwin /output/ffmpeg-8.1-darwin-x86_64.tar.gz /build/ffmpeg-8.1-darwin-x86_64.tar.gz
 
-CMD ["cp", "/build/ffmpeg-8.0-darwin-x86_64.tar.gz", "/output"]
+CMD ["cp", "/build/ffmpeg-8.1-darwin-x86_64.tar.gz", "/output"]

--- a/ffmpeg-linux-aarch64.dockerfile
+++ b/ffmpeg-linux-aarch64.dockerfile
@@ -354,6 +354,6 @@ RUN chmod +x /scripts/init/package.sh && /scripts/init/package.sh
 
 FROM alpine:latest AS final
 
-COPY --from=linux /build/ffmpeg-8.0-linux-aarch64.tar.gz /build/ffmpeg-8.0-linux-aarch64.tar.gz
+COPY --from=linux /build/ffmpeg-8.1-linux-aarch64.tar.gz /build/ffmpeg-8.1-linux-aarch64.tar.gz
 
-CMD ["cp", "/build/ffmpeg-8.0-linux-aarch64.tar.gz", "/output"]
+CMD ["cp", "/build/ffmpeg-8.1-linux-aarch64.tar.gz", "/output"]

--- a/ffmpeg-linux-x86_64.dockerfile
+++ b/ffmpeg-linux-x86_64.dockerfile
@@ -341,6 +341,6 @@ RUN chmod +x /scripts/init/package.sh && /scripts/init/package.sh
 
 FROM alpine:latest AS final
 
-COPY --from=linux /output/ffmpeg-8.0-linux-x86_64.tar.gz /build/ffmpeg-8.0-linux-x86_64.tar.gz
+COPY --from=linux /output/ffmpeg-8.1-linux-x86_64.tar.gz /build/ffmpeg-8.1-linux-x86_64.tar.gz
 
-CMD ["cp", "/build/ffmpeg-8.0-linux-x86_64.tar.gz", "/output"]
+CMD ["cp", "/build/ffmpeg-8.1-linux-x86_64.tar.gz", "/output"]

--- a/ffmpeg-windows-arm64.dockerfile
+++ b/ffmpeg-windows-arm64.dockerfile
@@ -192,6 +192,6 @@ RUN chmod +x /scripts/init/package.sh && /scripts/init/package.sh
 
 FROM alpine:latest AS final
 
-COPY --from=windows /output/ffmpeg-8.0-windows-aarch64.zip /build/ffmpeg-8.0-windows-aarch64.zip
+COPY --from=windows /output/ffmpeg-8.1-windows-aarch64.zip /build/ffmpeg-8.1-windows-aarch64.zip
 
-CMD ["cp", "/build/ffmpeg-8.0-windows-aarch64.zip", "/output"]
+CMD ["cp", "/build/ffmpeg-8.1-windows-aarch64.zip", "/output"]

--- a/ffmpeg-windows-x86_64.dockerfile
+++ b/ffmpeg-windows-x86_64.dockerfile
@@ -365,6 +365,6 @@ RUN chmod +x /scripts/init/package.sh && /scripts/init/package.sh
 
 FROM alpine:latest AS final
 
-COPY --from=windows /output/ffmpeg-8.0-windows-x86_64.zip /build/ffmpeg-8.0-windows-x86_64.zip
+COPY --from=windows /output/ffmpeg-8.1-windows-x86_64.zip /build/ffmpeg-8.1-windows-x86_64.zip
 
-CMD ["cp", "/build/ffmpeg-8.0-windows-x86_64.zip", "/output"]
+CMD ["cp", "/build/ffmpeg-8.1-windows-x86_64.zip", "/output"]

--- a/scripts/56-shaka-packager.sh
+++ b/scripts/56-shaka-packager.sh
@@ -15,30 +15,34 @@
 # No compilation required — shaka-packager ships fully static binaries.
 #
 # SHA256 verification:
-# TODO: pin SHA256 — fetch real hashes from
-#   https://github.com/shaka-project/shaka-packager/releases/tag/v3.7.2
-# Once fetched, replace each EXPECTED_SHA with the real value and remove this block.
+# Hashes computed from the official v3.7.2 GitHub release assets on
+# 2026-04-25. Update this block whenever SHAKA_VERSION is bumped.
 
 SHAKA_VERSION="v3.7.2"
 BASE_URL="https://github.com/shaka-project/shaka-packager/releases/download/${SHAKA_VERSION}"
 
-# Resolve platform binary name
+# Resolve platform binary name + expected sha256
 if [[ "${TARGET_OS}" == "windows" ]]; then
     BINARY_NAME="packager-win-x64.exe"
     DEST_NAME="packager.exe"
+    EXPECTED_SHA="61e26b68884c81d107ebd5b7ba6499bfa5a589b90245dac9683c5d50f999574a"
 elif [[ "${TARGET_OS}" == "darwin" ]]; then
     if [[ "${ARCH}" == "arm64" ]]; then
         BINARY_NAME="packager-osx-arm64"
+        EXPECTED_SHA="e755c7fb6f913e2c6de32efcf2a330f233110bfe3dc1b496d897e54d6d1ec9a6"
     else
         BINARY_NAME="packager-osx-x64"
+        EXPECTED_SHA="7f68db502c09807f013758885a3de259a641dc2258cb95011c4af0b203dca028"
     fi
     DEST_NAME="packager"
 else
     # linux
     if [[ "${ARCH}" == "aarch64" ]]; then
         BINARY_NAME="packager-linux-arm64"
+        EXPECTED_SHA="e4a43aaa8fdb87d0306876bc41581b371d7082e9d1b8469aef06a4e74004fd69"
     else
         BINARY_NAME="packager-linux-x64"
+        EXPECTED_SHA="88b022b8cb12602ddb539972efd07a3496ea64f8662a484798c96e95afa41fd8"
     fi
     DEST_NAME="packager"
 fi
@@ -56,8 +60,15 @@ curl -fsSL --retry 3 --retry-delay 5 \
     "${DOWNLOAD_URL}" \
     || { log "ERROR: Failed to download ${DOWNLOAD_URL}"; exit 1; }
 
-# TODO: verify SHA256 once hashes are pinned (see top of file).
-# sha256sum -c <(echo "${EXPECTED_SHA}  ${DEST_PATH}")
+ACTUAL_SHA=$(sha256sum "${DEST_PATH}" | awk '{print $1}')
+if [[ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]]; then
+    log "ERROR: SHA256 mismatch for ${BINARY_NAME}"
+    log "  expected: ${EXPECTED_SHA}"
+    log "  actual:   ${ACTUAL_SHA}"
+    rm -f "${DEST_PATH}"
+    exit 1
+fi
+log "SHA256 verified for ${BINARY_NAME}"
 
 if [[ "${TARGET_OS}" != "windows" ]]; then
     chmod +x "${DEST_PATH}"

--- a/scripts/56-shaka-packager.sh
+++ b/scripts/56-shaka-packager.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+#/******************************************/#
+#/*  NoMercy Entertainment — shaka-packager */#
+#/*  Pre-built binary download + staging   */#
+#/******************************************/#
+#
+# shaka-packager v3.7.2 — BSD-3-Clause
+# https://github.com/shaka-project/shaka-packager/releases/tag/v3.7.2
+#
+# This script downloads the official pre-built static binary for the
+# current build target and stages it next to ffmpeg in /ffmpeg/${TARGET_OS}/${ARCH}/
+# so it is included in the distribution tarball/zip.
+#
+# No compilation required — shaka-packager ships fully static binaries.
+#
+# SHA256 verification:
+# TODO: pin SHA256 — fetch real hashes from
+#   https://github.com/shaka-project/shaka-packager/releases/tag/v3.7.2
+# Once fetched, replace each EXPECTED_SHA with the real value and remove this block.
+
+SHAKA_VERSION="v3.7.2"
+BASE_URL="https://github.com/shaka-project/shaka-packager/releases/download/${SHAKA_VERSION}"
+
+# Resolve platform binary name
+if [[ "${TARGET_OS}" == "windows" ]]; then
+    BINARY_NAME="packager-win-x64.exe"
+    DEST_NAME="packager.exe"
+elif [[ "${TARGET_OS}" == "darwin" ]]; then
+    if [[ "${ARCH}" == "arm64" ]]; then
+        BINARY_NAME="packager-osx-arm64"
+    else
+        BINARY_NAME="packager-osx-x64"
+    fi
+    DEST_NAME="packager"
+else
+    # linux
+    if [[ "${ARCH}" == "aarch64" ]]; then
+        BINARY_NAME="packager-linux-arm64"
+    else
+        BINARY_NAME="packager-linux-x64"
+    fi
+    DEST_NAME="packager"
+fi
+
+DOWNLOAD_URL="${BASE_URL}/${BINARY_NAME}"
+DEST_DIR="/ffmpeg/${TARGET_OS}/${ARCH}"
+DEST_PATH="${DEST_DIR}/${DEST_NAME}"
+
+log "Downloading shaka-packager ${SHAKA_VERSION} (${BINARY_NAME})"
+
+mkdir -p "${DEST_DIR}"
+
+curl -fsSL --retry 3 --retry-delay 5 \
+    -o "${DEST_PATH}" \
+    "${DOWNLOAD_URL}" \
+    || { log "ERROR: Failed to download ${DOWNLOAD_URL}"; exit 1; }
+
+# TODO: verify SHA256 once hashes are pinned (see top of file).
+# sha256sum -c <(echo "${EXPECTED_SHA}  ${DEST_PATH}")
+
+if [[ "${TARGET_OS}" != "windows" ]]; then
+    chmod +x "${DEST_PATH}"
+    log "Set executable bit on ${DEST_PATH}"
+fi
+
+# Verify the binary exists and is non-empty
+if [[ ! -s "${DEST_PATH}" ]]; then
+    log "ERROR: ${DEST_PATH} is empty or missing after download"
+    exit 1
+fi
+
+log "shaka-packager ${SHAKA_VERSION} staged at ${DEST_PATH}"
+
+exit 0

--- a/scripts/init/package.sh
+++ b/scripts/init/package.sh
@@ -61,11 +61,11 @@ else
 fi
 cd /ffmpeg/${TARGET_OS}/${ARCH}
 if [[ ${TARGET_OS} == "windows" ]]; then
-    zip -r /build/ffmpeg-8.0-${TARGET_OS}-${ARCH}.zip . >/dev/null 2>&1
+    zip -r /build/ffmpeg-8.1-${TARGET_OS}-${ARCH}.zip . >/dev/null 2>&1
 else
-    tar -czf /build/ffmpeg-8.0-${TARGET_OS}-${ARCH}.tar.gz . >/dev/null 2>&1
+    tar -czf /build/ffmpeg-8.1-${TARGET_OS}-${ARCH}.tar.gz . >/dev/null 2>&1
 fi
-cp /build/ffmpeg-8.0-${TARGET_OS}-${ARCH}.* /output
+cp /build/ffmpeg-8.1-${TARGET_OS}-${ARCH}.* /output
 
 if [[ ${TARGET_OS} == "windows" ]]; then
     text_with_padding "✅ FFmpeg zip file created successfully" ""


### PR DESCRIPTION
## Summary

- CVE-2026-40962 — CVSS 9.8 critical. Integer overflow in `libavformat/mov.c` CENC subsample bounds checks (CWE-190), out-of-bounds write on crafted MP4.
- Fix is upstream commit `e392fb8c` ("avformat/mov: use 64bit in CENC subsample bounds checks"), first shipped in release `n8.1`. Not backported to `n8.0.1`.
- Bumped version string `8.0` → `8.1` across dockerfiles, `scripts/init/package.sh`, and workflow asset paths.

## Notes

- `nomercy-ffmpeg-secrets` patches (libaacs/libbluray) do not touch `mov.c` — no conflict.
- Cross-platform build validation happens in CI; local full build is multi-hour across 6 targets.

Refs #24