### PR TITLE
Verify release candidates on real hardware, and fix the suite that could not pass on 4 of 6 platforms

### DIFF
--- a/.github/scripts/sync-checklist.js
+++ b/.github/scripts/sync-checklist.js
@@ -23,17 +23,31 @@ const PLATFORM_LINE = /^(linux-x86_64|linux-aarch64|windows-x86_64|darwin-x86_64
 const HARDWARE_LINE = /hardware acceleration/i;
 const ACCELERATORS = ['nvenc', 'amf', 'vpl', 'videotoolbox'];
 
+// Walks nested directories on purpose. download-artifact flattens with
+// merge-multiple, but `gh run download` gives every artifact its own folder —
+// and a non-recursive read of that layout finds nothing, silently leaves every
+// box unticked, and reports six healthy platforms as unverified.
+function findVerdictFiles(directory) {
+  const found = [];
+  if (!fs.existsSync(directory)) return found;
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const full = path.join(directory, entry.name);
+    if (entry.isDirectory()) found.push(...findVerdictFiles(full));
+    else if (entry.name.endsWith('.json')) found.push(full);
+  }
+  return found;
+}
+
 function readVerdicts(directory) {
   const verdicts = new Map();
-  if (!fs.existsSync(directory)) return verdicts;
 
-  for (const entry of fs.readdirSync(directory)) {
-    if (!entry.endsWith('.json')) continue;
+  for (const file of findVerdictFiles(directory)) {
     let parsed;
     try {
-      parsed = JSON.parse(fs.readFileSync(path.join(directory, entry), 'utf8'));
+      parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
     } catch (error) {
-      console.error(`⚠️  ${entry}: unreadable (${error.message}) — treated as missing`);
+      console.error(`⚠️  ${path.basename(file)}: unreadable (${error.message}) — treated as missing`);
       continue;
     }
     if (parsed && parsed.platform) verdicts.set(parsed.platform, parsed);
@@ -262,4 +276,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { assess, assessHardware, rewriteChecklist, buildComment };
+module.exports = { assess, assessHardware, rewriteChecklist, buildComment, readVerdicts };

--- a/.github/scripts/sync-checklist.js
+++ b/.github/scripts/sync-checklist.js
@@ -95,14 +95,21 @@ function assess(verdict, expected) {
 // The hardware line covers NVENC / AMF / VPL. Nothing in the fleet can
 // positively exercise AMF or VPL, so it is satisfied by at least one
 // accelerator genuinely encoding, with the untestable ones reported as such.
-// Takes only the verdicts assess() already accepted. Reading the raw map here
-// would let a verdict this script refused for a platform box still tick the
-// hardware box, which is the same lie by a different route.
-function assessHardware(acceptedVerdicts) {
+// Takes the ASSESSED results, not the raw verdict map, and does the filtering
+// itself. Passing accepted verdicts in from the caller worked, but it left the
+// linkage as something to remember: reading the raw map here would once again
+// let a verdict refused for a platform box tick the hardware box, which is the
+// same lie by a different route. Demanding the assessed shape makes the wrong
+// call fail rather than pass quietly.
+function assessHardware(results) {
   const exercised = [];
   const unavailable = [];
 
-  for (const verdict of acceptedVerdicts) {
+  const accepted = [...results.values()]
+    .filter((entry) => entry && entry.assessment && entry.assessment.ok && entry.verdict)
+    .map((entry) => entry.verdict);
+
+  for (const verdict of accepted) {
     for (const test of verdict.report?.tests || []) {
       const name = test.name.toLowerCase();
       if (!ACCELERATORS.includes(name)) continue;
@@ -224,10 +231,7 @@ function main() {
     const verdict = verdicts.get(platform);
     results.set(platform, { verdict, assessment: assess(verdict, context) });
   }
-  const accepted = [...results.values()]
-    .filter((r) => r.assessment.ok && r.verdict)
-    .map((r) => r.verdict);
-  const hardware = assessHardware(accepted);
+  const hardware = assessHardware(results);
 
   const body = JSON.parse(gh(['pr', 'view', context.pr, '--repo', context.repo, '--json', 'body'])).body || '';
 

--- a/.github/scripts/sync-checklist.js
+++ b/.github/scripts/sync-checklist.js
@@ -214,6 +214,20 @@ function main() {
 
   const comment = buildComment(results, hardware, context);
 
+  // Rehearsal mode: prove the whole pipeline — runners, artifacts, verdicts and
+  // the tick decision — without editing someone's open release PR.
+  if (process.env.DRY_RUN === 'true') {
+    console.log('── DRY RUN — nothing will be written to the PR ──\n');
+    console.log(comment);
+    console.log('\n── checklist that would be written ──');
+    for (const [platform, { assessment }] of results) {
+      console.log(`  [${assessment.ok ? 'x' : ' '}] ${platform}${assessment.ok ? '' : ` — ${assessment.why}`}`);
+    }
+    console.log(`  [${hardware.ok ? 'x' : ' '}] hardware acceleration`);
+    console.log(updated === body ? '\nPR body unchanged.' : '\nPR body would change.');
+    return;
+  }
+
   if (updated !== body) {
     gh(['pr', 'edit', context.pr, '--repo', context.repo, '--body-file', '-'], updated);
     console.log('✅ PR checklist updated.');

--- a/.github/scripts/sync-checklist.js
+++ b/.github/scripts/sync-checklist.js
@@ -64,10 +64,20 @@ function assess(verdict, expected) {
     const stage = verdict.failed_stage ? `${verdict.failed_stage}: ${verdict.detail}` : '';
     return { ok: false, why: names ? `failed: ${names}` : stage || 'suite reported failure' };
   }
-  if (verdict.commit && expected.headSha && verdict.commit !== expected.headSha) {
+  // Absent is not the same as matching. These two fields are the entire reason
+  // a verdict from an older push cannot tick a box for a newer one, so a
+  // verdict that does not carry them has not proved anything about which build
+  // it tested.
+  if (!verdict.commit) {
+    return { ok: false, why: 'verdict does not say which commit it tested' };
+  }
+  if (expected.headSha && verdict.commit !== expected.headSha) {
     return { ok: false, why: `verdict is for commit ${verdict.commit.slice(0, 8)}, PR head is ${expected.headSha.slice(0, 8)}` };
   }
-  if (verdict.tag && expected.tag && verdict.tag !== expected.tag) {
+  if (!verdict.tag) {
+    return { ok: false, why: 'verdict does not say which release it tested' };
+  }
+  if (expected.tag && verdict.tag !== expected.tag) {
     return { ok: false, why: `verdict is for ${verdict.tag}, expected ${expected.tag}` };
   }
   if (!verdict.integrity || verdict.integrity.verified !== true) {
@@ -85,11 +95,14 @@ function assess(verdict, expected) {
 // The hardware line covers NVENC / AMF / VPL. Nothing in the fleet can
 // positively exercise AMF or VPL, so it is satisfied by at least one
 // accelerator genuinely encoding, with the untestable ones reported as such.
-function assessHardware(verdicts) {
+// Takes only the verdicts assess() already accepted. Reading the raw map here
+// would let a verdict this script refused for a platform box still tick the
+// hardware box, which is the same lie by a different route.
+function assessHardware(acceptedVerdicts) {
   const exercised = [];
   const unavailable = [];
 
-  for (const verdict of verdicts.values()) {
+  for (const verdict of acceptedVerdicts) {
     for (const test of verdict.report?.tests || []) {
       const name = test.name.toLowerCase();
       if (!ACCELERATORS.includes(name)) continue;
@@ -122,7 +135,11 @@ function rewriteChecklist(body, decide) {
       const match = line.match(/^(\s*-\s*\[)( |x|X)(\]\s*)(.*)$/);
       if (!match) return line;
       const label = match[4];
-      return `${match[1]}${decide(label) ? 'x' : ' '}${match[3]}${label}`;
+      // The current state has to be handed to decide(). label is the text AFTER
+      // the checkbox, so anything testing it for "[x]" can never match, and the
+      // unrecognised-line branch would clear a box a human ticked.
+      const wasChecked = match[2].toLowerCase() === 'x';
+      return `${match[1]}${decide(label, wasChecked) ? 'x' : ' '}${match[3]}${label}`;
     })
     .join('\n');
 
@@ -207,18 +224,22 @@ function main() {
     const verdict = verdicts.get(platform);
     results.set(platform, { verdict, assessment: assess(verdict, context) });
   }
-  const hardware = assessHardware(verdicts);
+  const accepted = [...results.values()]
+    .filter((r) => r.assessment.ok && r.verdict)
+    .map((r) => r.verdict);
+  const hardware = assessHardware(accepted);
 
   const body = JSON.parse(gh(['pr', 'view', context.pr, '--repo', context.repo, '--json', 'body'])).body || '';
 
-  const updated = rewriteChecklist(body, (label) => {
+  const updated = rewriteChecklist(body, (label, wasChecked) => {
     const platformMatch = label.match(PLATFORM_LINE);
     if (platformMatch) return results.get(platformMatch[1])?.assessment.ok === true;
     if (HARDWARE_LINE.test(label)) return hardware.ok;
-    // An unrecognised checklist line is never auto-ticked. A human added it for
-    // a reason this script does not know how to verify.
+    // An unrecognised checklist line is never auto-ticked, and never cleared
+    // either. A human added it for a reason this script cannot verify, and
+    // clearing it would block the merge with no way for them to tick out of it.
     console.error(`ℹ️  leaving unrecognised checklist item untouched: ${label}`);
-    return /^\s*-?\s*\[x\]/i.test(label);
+    return wasChecked;
   });
 
   if (updated === null) {

--- a/.github/scripts/sync-checklist.js
+++ b/.github/scripts/sync-checklist.js
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+// Ticks the PR test-checklist from verification verdicts, and posts the
+// evidence behind every tick.
+//
+// The rule this file exists to enforce: a box is ticked only when a verdict
+// file proves that THIS commit's artifact was tested on hardware that could
+// actually run it. Job success is not evidence — a job can pass for reasons
+// unrelated to the binary. Anything unproven is left unticked, which keeps the
+// merge blocked exactly as an untested platform should.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { START, END } = require('./check-checklist.js');
+
+const COMMENT_MARKER = '<!-- RC-VERIFICATION-REPORT -->';
+
+// Maps a checklist line to the verdict that is allowed to tick it. The hardware
+// line is special: it is satisfied by acceleration actually exercised somewhere
+// in the fleet, not by one platform.
+const PLATFORM_LINE = /^(linux-x86_64|linux-aarch64|windows-x86_64|darwin-x86_64|darwin-arm64|freebsd-x86_64)\b/;
+const HARDWARE_LINE = /hardware acceleration/i;
+const ACCELERATORS = ['nvenc', 'amf', 'vpl', 'videotoolbox'];
+
+function readVerdicts(directory) {
+  const verdicts = new Map();
+  if (!fs.existsSync(directory)) return verdicts;
+
+  for (const entry of fs.readdirSync(directory)) {
+    if (!entry.endsWith('.json')) continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(path.join(directory, entry), 'utf8'));
+    } catch (error) {
+      console.error(`⚠️  ${entry}: unreadable (${error.message}) — treated as missing`);
+      continue;
+    }
+    if (parsed && parsed.platform) verdicts.set(parsed.platform, parsed);
+  }
+  return verdicts;
+}
+
+// Every condition here is a reason a tick would be a lie.
+function assess(verdict, expected) {
+  if (!verdict) return { ok: false, why: 'no verdict produced (runner offline or job never ran)' };
+  if (verdict.verdict !== 'pass') {
+    const failed = (verdict.report?.tests || []).filter((t) => t.status === 'failed');
+    const names = failed.map((t) => t.name).join(', ');
+    const stage = verdict.failed_stage ? `${verdict.failed_stage}: ${verdict.detail}` : '';
+    return { ok: false, why: names ? `failed: ${names}` : stage || 'suite reported failure' };
+  }
+  if (verdict.commit && expected.headSha && verdict.commit !== expected.headSha) {
+    return { ok: false, why: `verdict is for commit ${verdict.commit.slice(0, 8)}, PR head is ${expected.headSha.slice(0, 8)}` };
+  }
+  if (verdict.tag && expected.tag && verdict.tag !== expected.tag) {
+    return { ok: false, why: `verdict is for ${verdict.tag}, expected ${expected.tag}` };
+  }
+  if (!verdict.integrity || verdict.integrity.verified !== true) {
+    return { ok: false, why: 'artifact digest was never checked against the manifest' };
+  }
+  if (!verdict.report || (verdict.report.totals?.total || 0) === 0) {
+    return { ok: false, why: 'verdict carries no test results' };
+  }
+  if ((verdict.report.totals?.failed || 0) > 0) {
+    return { ok: false, why: `${verdict.report.totals.failed} test(s) failed` };
+  }
+  return { ok: true, why: '' };
+}
+
+// The hardware line covers NVENC / AMF / VPL. Nothing in the fleet can
+// positively exercise AMF or VPL, so it is satisfied by at least one
+// accelerator genuinely encoding, with the untestable ones reported as such.
+function assessHardware(verdicts) {
+  const exercised = [];
+  const unavailable = [];
+
+  for (const verdict of verdicts.values()) {
+    for (const test of verdict.report?.tests || []) {
+      const name = test.name.toLowerCase();
+      if (!ACCELERATORS.includes(name)) continue;
+      if (test.status === 'passed') exercised.push(`${name} on ${verdict.platform}`);
+      if (test.status === 'failed') {
+        return { ok: false, why: `${test.name} failed on ${verdict.platform}`, exercised, unavailable };
+      }
+      if (test.status === 'skipped') unavailable.push(`${name}: ${test.reason}`);
+    }
+  }
+
+  if (exercised.length === 0) {
+    return { ok: false, why: 'no accelerator was exercised anywhere in the fleet', exercised, unavailable };
+  }
+  return { ok: true, why: '', exercised, unavailable };
+}
+
+function rewriteChecklist(body, decide) {
+  const start = body.indexOf(START);
+  const end = body.indexOf(END);
+  if (start === -1 || end === -1 || end < start) return null;
+
+  const head = body.slice(0, start + START.length);
+  const section = body.slice(start + START.length, end);
+  const tail = body.slice(end);
+
+  const rewritten = section
+    .split(/\r?\n/)
+    .map((line) => {
+      const match = line.match(/^(\s*-\s*\[)( |x|X)(\]\s*)(.*)$/);
+      if (!match) return line;
+      const label = match[4];
+      return `${match[1]}${decide(label) ? 'x' : ' '}${match[3]}${label}`;
+    })
+    .join('\n');
+
+  return head + rewritten + tail;
+}
+
+function buildComment(results, hardware, context) {
+  const rows = [...results.entries()].map(([platform, { assessment, verdict }]) => {
+    const icon = assessment.ok ? '✅' : '❌';
+    const totals = verdict?.report?.totals;
+    const counts = totals ? `${totals.passed} passed, ${totals.skipped} skipped, ${totals.failed} failed` : '—';
+    const host = verdict?.report?.host
+      ? `${verdict.report.host.os}/${verdict.report.host.arch}`
+      : '—';
+    const native = verdict?.execution
+      ? (verdict.execution.native ? 'native' : `via ${verdict.execution.translation}`)
+      : '—';
+    const digest = verdict?.integrity?.sha256 ? `\`${verdict.integrity.sha256.slice(0, 12)}\`` : '—';
+    const note = assessment.ok ? '' : ` — ${assessment.why}`;
+    return `| ${icon} ${platform} | ${counts} | ${host} | ${native} | ${digest}${note} |`;
+  });
+
+  const lines = [
+    COMMENT_MARKER,
+    `## RC verification — ${context.tag}`,
+    '',
+    `Ran the full suite on real hardware for commit \`${context.headSha.slice(0, 8)}\`.`,
+    'Each row is the machine that executed the binary, not a summary of a build job.',
+    '',
+    '| Platform | Result | Host | Execution | Artifact SHA-256 |',
+    '|---|---|---|---|---|',
+    ...rows,
+    '',
+    `**Hardware acceleration:** ${hardware.ok ? '✅' : '❌'} ${hardware.ok ? 'verified' : hardware.why}`,
+  ];
+
+  if (hardware.exercised.length > 0) {
+    lines.push('', 'Exercised on real hardware:', ...hardware.exercised.map((item) => `- ${item}`));
+  }
+  if (hardware.unavailable.length > 0) {
+    const unique = [...new Set(hardware.unavailable)];
+    lines.push(
+      '',
+      'Not exercised — no such hardware in the verification fleet:',
+      ...unique.map((item) => `- ${item}`),
+    );
+  }
+
+  lines.push('', `[Full logs and verdict artifacts](${context.runUrl})`);
+  return lines.join('\n');
+}
+
+function gh(args, input) {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    input,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+}
+
+function main() {
+  const directory = process.argv[2] || 'verdicts';
+  const context = {
+    repo: process.env.REPO,
+    pr: process.env.PR,
+    tag: process.env.TAG || '',
+    headSha: process.env.HEAD_SHA || '',
+    runUrl: process.env.RUN_URL || '',
+  };
+
+  if (!context.repo || !context.pr) {
+    console.error('❌ REPO and PR must be set.');
+    process.exit(1);
+  }
+
+  const verdicts = readVerdicts(directory);
+  const results = new Map();
+  for (const platform of [
+    'linux-x86_64', 'linux-aarch64', 'windows-x86_64',
+    'darwin-x86_64', 'darwin-arm64', 'freebsd-x86_64',
+  ]) {
+    const verdict = verdicts.get(platform);
+    results.set(platform, { verdict, assessment: assess(verdict, context) });
+  }
+  const hardware = assessHardware(verdicts);
+
+  const body = JSON.parse(gh(['pr', 'view', context.pr, '--repo', context.repo, '--json', 'body'])).body || '';
+
+  const updated = rewriteChecklist(body, (label) => {
+    const platformMatch = label.match(PLATFORM_LINE);
+    if (platformMatch) return results.get(platformMatch[1])?.assessment.ok === true;
+    if (HARDWARE_LINE.test(label)) return hardware.ok;
+    // An unrecognised checklist line is never auto-ticked. A human added it for
+    // a reason this script does not know how to verify.
+    console.error(`ℹ️  leaving unrecognised checklist item untouched: ${label}`);
+    return /^\s*-?\s*\[x\]/i.test(label);
+  });
+
+  if (updated === null) {
+    console.error('❌ Test-checklist delimiters not found in the PR body.');
+    process.exit(1);
+  }
+
+  const comment = buildComment(results, hardware, context);
+
+  if (updated !== body) {
+    gh(['pr', 'edit', context.pr, '--repo', context.repo, '--body-file', '-'], updated);
+    console.log('✅ PR checklist updated.');
+  } else {
+    console.log('ℹ️  PR checklist already matches the verdicts.');
+  }
+
+  // One sticky comment, edited in place, so a PR that is pushed to repeatedly
+  // does not accumulate a wall of near-identical reports.
+  const existing = JSON.parse(
+    gh(['pr', 'view', context.pr, '--repo', context.repo, '--json', 'comments']),
+  ).comments || [];
+  const previous = existing.filter((c) => (c.body || '').includes(COMMENT_MARKER)).pop();
+
+  if (previous && previous.url) {
+    const id = previous.url.split('-').pop();
+    gh(['api', '-X', 'PATCH', `repos/${context.repo}/issues/comments/${id}`,
+      '-F', 'body=@-'], comment);
+    console.log('✅ Evidence comment updated.');
+  } else {
+    gh(['pr', 'comment', context.pr, '--repo', context.repo, '--body-file', '-'], comment);
+    console.log('✅ Evidence comment posted.');
+  }
+
+  const failed = [...results.values()].filter((r) => !r.assessment.ok);
+  if (failed.length > 0 || !hardware.ok) {
+    console.error(`❌ ${failed.length} platform(s) unverified; checklist left incomplete.`);
+    process.exit(1);
+  }
+  console.log('✅ Every checklist item verified.');
+}
+
+if (require.main === module) main();
+
+module.exports = { assess, assessHardware, rewriteChecklist, buildComment };

--- a/.github/scripts/sync-checklist.test.js
+++ b/.github/scripts/sync-checklist.test.js
@@ -66,8 +66,10 @@ assert.strictEqual(
 );
 
 // ── Hardware line ─────────────────────────────────────────────────────────
-const withTests = (platform, tests) =>
-  new Map([[platform, { platform, report: { tests } }]]);
+// assessHardware now takes verdicts assess() has ALREADY accepted, so these
+// build the accepted shape rather than a raw map. Building them any other way
+// would have the tests assert the permissive behaviour as the specification.
+const withTests = (platform, tests) => [{ platform, report: { tests } }];
 
 let hw = assessHardware(withTests('windows-x86_64', [
   { name: 'NVENC', status: 'passed' },
@@ -104,6 +106,43 @@ assert.match(rewritten, /- \[ \] a stray box above/, 'leaves boxes above the mar
 assert.match(rewritten, /- \[ \] a stray box below/, 'leaves boxes below the markers alone');
 
 assert.strictEqual(rewriteChecklist('no markers', () => true), null, 'refuses a body with no delimiters');
+
+// A human-ticked line the script does not recognise must survive. Clearing it
+// blocks the merge in check-checklist.js and gets cleared again on every push,
+// so nobody can tick their way out of it.
+const humanBody = [
+  '<!-- TEST-CHECKLIST-START -->',
+  '- [ ] linux-x86_64 — tested on real hardware',
+  '- [x] Release notes reviewed by a human',
+  '<!-- TEST-CHECKLIST-END -->',
+].join('\n');
+const humanKept = rewriteChecklist(humanBody, (label, wasChecked) =>
+  label.startsWith('linux-x86_64') ? true : wasChecked);
+assert.match(humanKept, /- \[x\] Release notes reviewed by a human/,
+  'a human-ticked unrecognised item stays ticked');
+assert.match(humanKept, /- \[x\] linux-x86_64/, 'and the recognised one still ticks');
+
+// ── Missing proof is not the same as matching proof ───────────────────────
+const { commit: _c, ...noCommit } = passingVerdict();
+assert.strictEqual(assess(noCommit, CONTEXT).ok, false,
+  'a verdict with no commit never ticks');
+assert.strictEqual(assess({ ...passingVerdict(), commit: '' }, CONTEXT).ok, false,
+  'an empty commit is a refusal, not a skipped check');
+
+const { tag: _t, ...noTag } = passingVerdict();
+assert.strictEqual(assess(noTag, CONTEXT).ok, false,
+  'a verdict with no tag never ticks');
+assert.strictEqual(assess({ ...passingVerdict(), tag: '' }, CONTEXT).ok, false,
+  'an empty tag is a refusal, not a skipped check');
+
+// ── The hardware line inherits every refusal assess() makes ───────────────
+// A verdict assess() rejected must not tick the hardware box by another route.
+const rejected = { ...passingVerdict(), commit: 'deadbeef', platform: 'windows-x86_64' };
+rejected.report.tests = [{ name: 'NVENC', status: 'passed' }];
+assert.strictEqual(assess(rejected, CONTEXT).ok, false, 'stale commit is refused');
+assert.strictEqual(assessHardware([]).ok, false,
+  'with no accepted verdicts the hardware line cannot be satisfied');
+
 
 console.log('all sync-checklist tests passed');
 

--- a/.github/scripts/sync-checklist.test.js
+++ b/.github/scripts/sync-checklist.test.js
@@ -1,0 +1,108 @@
+const assert = require('assert');
+const { assess, assessHardware, rewriteChecklist } = require('./sync-checklist');
+
+const HEAD = 'a'.repeat(40);
+const CONTEXT = { headSha: HEAD, tag: 'v1.0.39-rc' };
+
+const passingVerdict = (overrides = {}) => ({
+  platform: 'linux-x86_64',
+  tag: 'v1.0.39-rc',
+  commit: HEAD,
+  verdict: 'pass',
+  integrity: { verified: true, sha256: 'f'.repeat(64) },
+  report: {
+    totals: { passed: 22, failed: 0, skipped: 4, total: 26 },
+    tests: [{ name: 'LIBX264', status: 'passed' }],
+  },
+  ...overrides,
+});
+
+// ── A tick requires proof, and each missing proof is its own refusal ───────
+assert.strictEqual(assess(passingVerdict(), CONTEXT).ok, true, 'a complete passing verdict ticks');
+
+assert.strictEqual(assess(undefined, CONTEXT).ok, false, 'a missing verdict never ticks');
+assert.match(assess(undefined, CONTEXT).why, /no verdict/, 'says the verdict is missing');
+
+assert.strictEqual(
+  assess(passingVerdict({ commit: 'b'.repeat(40) }), CONTEXT).ok,
+  false,
+  'a verdict for another commit never ticks',
+);
+
+assert.strictEqual(
+  assess(passingVerdict({ tag: 'v1.0.38-rc' }), CONTEXT).ok,
+  false,
+  'a verdict for another RC never ticks',
+);
+
+assert.strictEqual(
+  assess(passingVerdict({ integrity: { verified: false } }), CONTEXT).ok,
+  false,
+  'an unchecked artifact digest never ticks',
+);
+
+assert.strictEqual(
+  assess(passingVerdict({ report: { totals: { passed: 0, failed: 0, skipped: 0, total: 0 }, tests: [] } }), CONTEXT).ok,
+  false,
+  'an empty result set never ticks',
+);
+
+// A suite can report pass while carrying failures; the totals are authoritative.
+assert.strictEqual(
+  assess(passingVerdict({
+    report: {
+      totals: { passed: 20, failed: 2, skipped: 4, total: 26 },
+      tests: [{ name: 'LIBX264', status: 'failed' }],
+    },
+  }), CONTEXT).ok,
+  false,
+  'a verdict claiming pass with failed totals never ticks',
+);
+
+assert.strictEqual(
+  assess(passingVerdict({ verdict: 'fail', report: { totals: { passed: 1, failed: 1, total: 2, skipped: 0 }, tests: [{ name: 'NVENC', status: 'failed' }] } }), CONTEXT).ok,
+  false,
+  'an explicit fail never ticks',
+);
+
+// ── Hardware line ─────────────────────────────────────────────────────────
+const withTests = (platform, tests) =>
+  new Map([[platform, { platform, report: { tests } }]]);
+
+let hw = assessHardware(withTests('windows-x86_64', [
+  { name: 'NVENC', status: 'passed' },
+  { name: 'AMF', status: 'skipped', reason: 'no AMD display adapter' },
+]));
+assert.strictEqual(hw.ok, true, 'one real accelerator satisfies the hardware line');
+assert.deepStrictEqual(hw.exercised, ['nvenc on windows-x86_64'], 'names what actually ran');
+assert.strictEqual(hw.unavailable.length, 1, 'records what could not be tested');
+
+hw = assessHardware(withTests('linux-x86_64', [
+  { name: 'NVENC', status: 'skipped', reason: 'no NVIDIA adapter' },
+  { name: 'AMF', status: 'skipped', reason: 'no AMD adapter' },
+]));
+assert.strictEqual(hw.ok, false, 'all-skipped acceleration does not satisfy the line');
+
+hw = assessHardware(withTests('windows-x86_64', [{ name: 'NVENC', status: 'failed' }]));
+assert.strictEqual(hw.ok, false, 'a failed accelerator fails the line');
+
+// ── Rewriting is confined to the delimited section ────────────────────────
+const body = [
+  'intro',
+  '- [ ] a stray box above the markers',
+  '<!-- TEST-CHECKLIST-START -->',
+  '- [ ] linux-x86_64 — tested on real hardware',
+  '- [x] darwin-arm64 — tested on real hardware',
+  '<!-- TEST-CHECKLIST-END -->',
+  '- [ ] a stray box below the markers',
+].join('\n');
+
+const rewritten = rewriteChecklist(body, (label) => label.startsWith('linux-x86_64'));
+assert.match(rewritten, /- \[x\] linux-x86_64/, 'ticks a verified platform');
+assert.match(rewritten, /- \[ \] darwin-arm64/, 'unticks a platform that lost its proof');
+assert.match(rewritten, /- \[ \] a stray box above/, 'leaves boxes above the markers alone');
+assert.match(rewritten, /- \[ \] a stray box below/, 'leaves boxes below the markers alone');
+
+assert.strictEqual(rewriteChecklist('no markers', () => true), null, 'refuses a body with no delimiters');
+
+console.log('all sync-checklist tests passed');

--- a/.github/scripts/sync-checklist.test.js
+++ b/.github/scripts/sync-checklist.test.js
@@ -106,3 +106,27 @@ assert.match(rewritten, /- \[ \] a stray box below/, 'leaves boxes below the mar
 assert.strictEqual(rewriteChecklist('no markers', () => true), null, 'refuses a body with no delimiters');
 
 console.log('all sync-checklist tests passed');
+
+// ── Verdicts must be found however the artifacts were laid out ────────────
+// download-artifact flattens; `gh run download` nests one folder per artifact.
+// A non-recursive read of the nested layout finds nothing and would report every
+// healthy platform as unverified.
+const fs = require('fs');
+const os = require('os');
+const pathModule = require('path');
+const { readVerdicts } = require('./sync-checklist');
+
+const root = fs.mkdtempSync(pathModule.join(os.tmpdir(), 'verdicts-'));
+fs.writeFileSync(pathModule.join(root, 'verdict-flat.json'), JSON.stringify({ platform: 'linux-x86_64' }));
+const nested = pathModule.join(root, 'verdict-darwin-arm64');
+fs.mkdirSync(nested);
+fs.writeFileSync(pathModule.join(nested, 'verdict-darwin-arm64.json'), JSON.stringify({ platform: 'darwin-arm64' }));
+
+const discovered = readVerdicts(root);
+assert.strictEqual(discovered.size, 2, 'finds both flat and nested verdicts');
+assert.ok(discovered.has('linux-x86_64'), 'finds the flat verdict');
+assert.ok(discovered.has('darwin-arm64'), 'finds the nested verdict');
+assert.strictEqual(readVerdicts(pathModule.join(root, 'missing')).size, 0, 'a missing directory yields nothing');
+fs.rmSync(root, { recursive: true, force: true });
+
+console.log('verdict discovery tests passed');

--- a/.github/scripts/sync-checklist.test.js
+++ b/.github/scripts/sync-checklist.test.js
@@ -66,12 +66,13 @@ assert.strictEqual(
 );
 
 // ── Hardware line ─────────────────────────────────────────────────────────
-// assessHardware now takes verdicts assess() has ALREADY accepted, so these
-// build the accepted shape rather than a raw map. Building them any other way
-// would have the tests assert the permissive behaviour as the specification.
-const withTests = (platform, tests) => [{ platform, report: { tests } }];
+// assessHardware takes the ASSESSED results, so these build that shape. A raw
+// verdict map no longer satisfies it, which is what stops the permissive
+// behaviour being written down here as the specification.
+const accepted = (platform, tests) =>
+  new Map([[platform, { verdict: { platform, report: { tests } }, assessment: { ok: true } }]]);
 
-let hw = assessHardware(withTests('windows-x86_64', [
+let hw = assessHardware(accepted('windows-x86_64', [
   { name: 'NVENC', status: 'passed' },
   { name: 'AMF', status: 'skipped', reason: 'no AMD display adapter' },
 ]));
@@ -79,13 +80,13 @@ assert.strictEqual(hw.ok, true, 'one real accelerator satisfies the hardware lin
 assert.deepStrictEqual(hw.exercised, ['nvenc on windows-x86_64'], 'names what actually ran');
 assert.strictEqual(hw.unavailable.length, 1, 'records what could not be tested');
 
-hw = assessHardware(withTests('linux-x86_64', [
+hw = assessHardware(accepted('linux-x86_64', [
   { name: 'NVENC', status: 'skipped', reason: 'no NVIDIA adapter' },
   { name: 'AMF', status: 'skipped', reason: 'no AMD adapter' },
 ]));
 assert.strictEqual(hw.ok, false, 'all-skipped acceleration does not satisfy the line');
 
-hw = assessHardware(withTests('windows-x86_64', [{ name: 'NVENC', status: 'failed' }]));
+hw = assessHardware(accepted('windows-x86_64', [{ name: 'NVENC', status: 'failed' }]));
 assert.strictEqual(hw.ok, false, 'a failed accelerator fails the line');
 
 // ── Rewriting is confined to the delimited section ────────────────────────
@@ -137,13 +138,32 @@ assert.strictEqual(assess({ ...passingVerdict(), tag: '' }, CONTEXT).ok, false,
 
 // ── The hardware line inherits every refusal assess() makes ───────────────
 // A verdict assess() rejected must not tick the hardware box by another route.
+// The linkage itself, not just the empty case: a verdict carrying a PASSING
+// accelerator that assess() refused must not satisfy the hardware line.
 const rejected = { ...passingVerdict(), commit: 'deadbeef', platform: 'windows-x86_64' };
-rejected.report.tests = [{ name: 'NVENC', status: 'passed' }];
-assert.strictEqual(assess(rejected, CONTEXT).ok, false, 'stale commit is refused');
-assert.strictEqual(assessHardware([]).ok, false,
-  'with no accepted verdicts the hardware line cannot be satisfied');
+rejected.report = { ...rejected.report, tests: [{ name: 'NVENC', status: 'passed' }] };
+const rejectedAssessment = assess(rejected, CONTEXT);
+assert.strictEqual(rejectedAssessment.ok, false, 'stale commit is refused');
 
+const mixed = new Map([
+  ['windows-x86_64', { verdict: rejected, assessment: rejectedAssessment }],
+]);
+assert.strictEqual(assessHardware(mixed).ok, false,
+  'a passing accelerator inside a REFUSED verdict does not tick the hardware line');
+assert.deepStrictEqual(assessHardware(mixed).exercised, [],
+  'and it is not even reported as exercised');
 
+// The same verdict, accepted, does satisfy it - so the filter has not
+// overshot into refusing everything.
+const okAssessment = { ok: true };
+const sameButAccepted = new Map([
+  ['windows-x86_64', { verdict: rejected, assessment: okAssessment }],
+]);
+assert.strictEqual(assessHardware(sameButAccepted).ok, true,
+  'the identical verdict, once accepted, satisfies the hardware line');
+
+assert.strictEqual(assessHardware(new Map()).ok, false,
+  'with no verdicts at all the hardware line cannot be satisfied');
 console.log('all sync-checklist tests passed');
 
 // ── Verdicts must be found however the artifacts were laid out ────────────

--- a/.github/workflows/fleet-health.yml
+++ b/.github/workflows/fleet-health.yml
@@ -1,0 +1,110 @@
+name: Fleet Health
+
+# Confirms the RC verification fleet is alive and still has the hardware it is
+# trusted to test.
+#
+# Without this, a runner that died quietly stays invisible until a release is
+# waiting on it, and the failure looks like a broken build rather than a broken
+# machine. Running the capability probe (not just a ping) also catches the worse
+# case: a host that is up but has lost its GPU, which would silently downgrade a
+# hardware check into a skip.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            labels: '["self-hosted","ffmpeg-verify","linux-x86_64"]'
+            shell: bash
+          - name: darwin-arm64
+            labels: '["self-hosted","ffmpeg-verify","darwin-arm64"]'
+            shell: bash
+          - name: windows-x86_64
+            labels: '["self-hosted","ffmpeg-verify","windows-x86_64"]'
+            shell: pwsh
+    runs-on: ${{ fromJSON(matrix.labels) }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Probe capabilities (unix)
+        if: matrix.shell == 'bash'
+        shell: bash
+        run: |
+          echo "### ${{ matrix.name }} — $(uname -srm)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          bash tests/lib/capabilities.sh | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Probe capabilities (windows)
+        if: matrix.shell == 'pwsh'
+        shell: pwsh
+        run: |
+          . ./tests/lib/capabilities.ps1
+          "### ${{ matrix.name }} — $([System.Environment]::OSVersion.VersionString)" |
+            Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          '```' | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          foreach ($feature in 'nvenc', 'amf', 'vpl', 'videotoolbox') {
+            $line = "{0,-14} {1}" -f $feature, (Hw-Capability -Feature $feature)
+            Write-Host $line
+            $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          }
+          '```' | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
+          # This host is the fleet's only NVENC hardware. If it loses the GPU,
+          # the hardware checklist line would quietly downgrade to a skip.
+          if ((Hw-Capability -Feature 'nvenc') -ne 'available') {
+            throw 'NVENC is no longer available on the only host that can verify it.'
+          }
+
+  # Reports which verification targets have no online runner at all. Split from
+  # the probe jobs on purpose: those cannot report a runner that never picked up
+  # a job, because they would simply queue forever.
+  registry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check every verification label has an online runner
+        env:
+          GH_TOKEN: ${{ secrets.FLEET_READ_TOKEN || github.token }}
+          ORG: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          REQUIRED="linux-x86_64 linux-aarch64 windows-x86_64 darwin-x86_64 darwin-arm64 freebsd-driver"
+
+          if ! gh api "orgs/${ORG}/actions/runners" --jq '.runners' > runners.json 2>/dev/null; then
+            echo "::warning::Cannot read the org runner list with this token — skipping the registry check."
+            exit 0
+          fi
+
+          missing=0
+          {
+            echo "| Label | Online runner |"
+            echo "|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for label in $REQUIRED; do
+            name=$(jq -r --arg l "$label" \
+              'map(select(.status == "online" and any(.labels[]; .name == $l))) | .[0].name // ""' \
+              runners.json)
+            if [[ -z "$name" ]]; then
+              echo "| \`${label}\` | ❌ none online |" >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::No online runner carries the '${label}' label."
+              missing=$((missing + 1))
+            else
+              echo "| \`${label}\` | ✅ ${name} |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+          [[ "$missing" -eq 0 ]] || exit 1
+          echo "✅ Every verification target has an online runner."

--- a/.github/workflows/pr-guards.yml
+++ b/.github/workflows/pr-guards.yml
@@ -25,6 +25,23 @@ jobs:
           fi
           echo "✅ PR source branch is dev."
 
+  # The checklist scripts decide whether a merge-blocking box gets ticked, so
+  # their refusal paths are the guarantee. Nothing was running these tests, and
+  # a regression in them is silent by construction: the failure mode is a box
+  # that ticks when it should not.
+  checklist-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Test the checklist scripts
+        run: |
+          node .github/scripts/sync-checklist.test.js
+          node .github/scripts/check-checklist.test.js
+
   checklist-complete:
     runs-on: ubuntu-latest
     steps:
@@ -39,7 +56,7 @@ jobs:
   # checks so a failed/ skipped dependency reliably fails this job (a job
   # skipped via failed `needs` can otherwise be miscounted as passing).
   pr-validation:
-    needs: [guard-source-branch, checklist-complete]
+    needs: [guard-source-branch, checklist-complete, checklist-scripts]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +64,11 @@ jobs:
         run: |
           guard='${{ needs.guard-source-branch.result }}'
           checklist='${{ needs.checklist-complete.result }}'
+          scripts='${{ needs.checklist-scripts.result }}'
+          if [[ "$scripts" != "success" ]]; then
+            echo "❌ The checklist scripts' own tests did not pass."
+            exit 1
+          fi
           if [[ "$guard" != "success" || "$checklist" != "success" ]]; then
             echo "❌ PR gates failed: guard=$guard checklist=$checklist"
             exit 1

--- a/.github/workflows/pr-guards.yml
+++ b/.github/workflows/pr-guards.yml
@@ -1,10 +1,15 @@
 name: PR Guards
 
-# Fast, build-free gates for PRs into master. `edited` is included so the
-# checklist re-evaluates the moment a reviewer ticks a box.
+# Fast, build-free gates. `edited` is included so the checklist re-evaluates
+# the moment a reviewer ticks a box.
+#
+# dev is here as well as master because work reaches master through dev, so a
+# master-only trigger means the scripts that decide whether a merge-blocking box
+# gets ticked are first tested on the PR that is already using them. The two
+# master-only gates below stay master-only.
 on:
   pull_request:
-    branches: [master]
+    branches: [master, dev]
     types: [opened, edited, synchronize, reopened]
 
 concurrency:
@@ -13,6 +18,7 @@ concurrency:
 
 jobs:
   guard-source-branch:
+    if: github.base_ref == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Enforce PR source branch is dev
@@ -43,6 +49,7 @@ jobs:
           node .github/scripts/check-checklist.test.js
 
   checklist-complete:
+    if: github.base_ref == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -65,10 +72,28 @@ jobs:
           guard='${{ needs.guard-source-branch.result }}'
           checklist='${{ needs.checklist-complete.result }}'
           scripts='${{ needs.checklist-scripts.result }}'
+          base='${{ github.base_ref }}'
+
+          # Runs for every base, so it is never allowed to be skipped.
           if [[ "$scripts" != "success" ]]; then
-            echo "❌ The checklist scripts' own tests did not pass."
+            echo "❌ The checklist scripts' own tests did not pass (got '$scripts')."
             exit 1
           fi
+
+          # The other two are master-only by design. On a dev PR they report
+          # 'skipped', which is the correct outcome rather than a pass to be
+          # waved through — so it is accepted here for dev and nowhere else.
+          if [[ "$base" != "master" ]]; then
+            for name in guard:"$guard" checklist:"$checklist"; do
+              if [[ "${name#*:}" != "skipped" ]]; then
+                echo "❌ ${name%%:*} should have been skipped on a ${base} PR, got '${name#*:}'."
+                exit 1
+              fi
+            done
+            echo "✅ Script tests passed; the master-only gates correctly did not run."
+            exit 0
+          fi
+
           if [[ "$guard" != "success" || "$checklist" != "success" ]]; then
             echo "❌ PR gates failed: guard=$guard checklist=$checklist"
             exit 1

--- a/.github/workflows/verify-rc.yml
+++ b/.github/workflows/verify-rc.yml
@@ -21,6 +21,11 @@ on:
         description: 'PR number to verify'
         required: true
         type: string
+      dry_run:
+        description: 'Report what would be ticked without editing the PR'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: verify-rc-${{ github.event.workflow_run.head_sha || inputs.pr }}
@@ -341,4 +346,5 @@ jobs:
           TAG: ${{ needs.resolve.outputs.tag }}
           HEAD_SHA: ${{ needs.resolve.outputs.head-sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: node .github/scripts/sync-checklist.js verdicts

--- a/.github/workflows/verify-rc.yml
+++ b/.github/workflows/verify-rc.yml
@@ -169,15 +169,16 @@ jobs:
           mkdir -p rc
 
           # python3 rather than jq: jq is absent from a stock macOS runner,
-          # python3 is present on every host in this fleet.
+          # python3 is present on every host in this fleet. The variables are
+          # passed as environment, which must precede the command — trailing
+          # NAME=value would be argv and never reach os.environ.
           asset_url() {
-            printf '%s' "$ASSETS" | python3 -c \
-              "import json,sys,os; print(next((a['url'] for a in json.load(sys.stdin) if a['name']==os.environ['N']),''))" N="$1"
+            printf '%s' "$ASSETS" | N="$1" python3 -c \
+              "import json,sys,os; print(next((a['url'] for a in json.load(sys.stdin) if a['name']==os.environ['N']),''))"
           }
 
-          ARCHIVE=$(printf '%s' "$ASSETS" | python3 -c \
-            "import json,sys,os; print(next((a['name'] for a in json.load(sys.stdin) if os.environ['P'] in a['name'] and a['name'].endswith(os.environ['E'])),''))" \
-            P="$PLATFORM" E="$EXT")
+          ARCHIVE=$(printf '%s' "$ASSETS" | P="$PLATFORM" E="$EXT" python3 -c \
+            "import json,sys,os; print(next((a['name'] for a in json.load(sys.stdin) if os.environ['P'] in a['name'] and a['name'].endswith(os.environ['E'])),''))")
           [[ -n "$ARCHIVE" ]] || { echo "::error::no ${PLATFORM} archive in ${TAG}"; exit 1; }
 
           for name in "$ARCHIVE" manifest.json; do

--- a/.github/workflows/verify-rc.yml
+++ b/.github/workflows/verify-rc.yml
@@ -1,0 +1,344 @@
+name: Verify RC
+
+# Runs the full manual suite against a Release Candidate on real hardware, one
+# job per checklist line, and ticks only the boxes whose hardware actually
+# reported a pass.
+#
+# This replaces a human downloading six archives and running six scripts. It is
+# deliberately NOT a rubber stamp: a box is ticked from the verdict artifact a
+# runner produced, never from a job's exit status, and every verdict names the
+# SHA-256 of the bytes it tested. If a platform's runner is offline, its box
+# stays empty and the merge stays blocked — the same outcome as nobody testing
+# it, which is the honest one.
+
+on:
+  workflow_run:
+    workflows: ["CI/CD Pipeline"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to verify'
+        required: true
+        type: string
+
+concurrency:
+  group: verify-rc-${{ github.event.workflow_run.head_sha || inputs.pr }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # ── Work out which PR and which RC we are verifying ───────────────────────
+  # Everything downstream is pinned to the head SHA resolved here, so a verify
+  # run that started against an older push can never tick boxes for a newer one.
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.resolve.outputs.should-run }}
+      pr: ${{ steps.resolve.outputs.pr }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      head-sha: ${{ steps.resolve.outputs.head-sha }}
+      assets: ${{ steps.resolve.outputs.assets }}
+    steps:
+      - name: Resolve PR and Release Candidate
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          INPUT_PR: ${{ inputs.pr }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT" == "workflow_run" ]]; then
+            if [[ "$RUN_EVENT" != "pull_request" || "$RUN_CONCLUSION" != "success" ]]; then
+              echo "Build was ${RUN_CONCLUSION} on a ${RUN_EVENT} event — nothing to verify."
+              echo "should-run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # PRs into master are only accepted from dev (pr-guards enforces it),
+            # so the open dev->master PR is unambiguous.
+            PR=$(gh pr list --repo "$REPO" --head dev --base master --state open \
+                   --json number --jq '.[0].number // empty')
+          else
+            PR="$INPUT_PR"
+          fi
+
+          if [[ -z "$PR" ]]; then
+            echo "No open dev->master PR — nothing to verify."
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+
+          # The RC is republished on every PR push. Only accept the one built
+          # from exactly this head, or we would test yesterday's binaries and
+          # tick today's checklist.
+          TAG=$(gh release list --repo "$REPO" --limit 30 --json tagName,isPrerelease \
+                  --jq '[.[] | select(.isPrerelease)][0].tagName // empty')
+          if [[ -z "$TAG" ]]; then
+            echo "::error::No prerelease found to verify."
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TARGET=$(gh api "repos/${REPO}/releases/tags/${TAG}" --jq '.target_commitish')
+          if [[ "$TARGET" != "$HEAD_SHA" ]]; then
+            echo "::warning::RC ${TAG} was built from ${TARGET} but PR #${PR} head is ${HEAD_SHA} — skipping."
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Emit the asset id map once so every runner can fetch by API URL,
+          # which works the same whether the repo is public or private.
+          ASSETS=$(gh api "repos/${REPO}/releases/tags/${TAG}" \
+            --jq '[.assets[] | {name: .name, url: .url}] | tojson')
+
+          {
+            echo "should-run=true"
+            echo "pr=${PR}"
+            echo "tag=${TAG}"
+            echo "head-sha=${HEAD_SHA}"
+            echo "assets=${ASSETS}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Verifying PR #${PR} @ ${HEAD_SHA} against ${TAG}"
+
+  # ── One job per checklist platform, each on its own real machine ──────────
+  verify:
+    needs: resolve
+    if: needs.resolve.outputs.should-run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            ext: tar.gz
+            labels: '["self-hosted","ffmpeg-verify","linux-x86_64"]'
+            via: native
+          - platform: linux-aarch64
+            ext: tar.gz
+            labels: '["self-hosted","ffmpeg-verify","linux-aarch64"]'
+            via: lima
+          - platform: darwin-arm64
+            ext: tar.gz
+            labels: '["self-hosted","ffmpeg-verify","darwin-arm64"]'
+            via: native
+          - platform: darwin-x86_64
+            ext: tar.gz
+            labels: '["self-hosted","ffmpeg-verify","darwin-x86_64"]'
+            via: native
+          - platform: freebsd-x86_64
+            ext: tar.gz
+            labels: '["self-hosted","ffmpeg-verify","freebsd-driver"]'
+            via: ssh
+          - platform: windows-x86_64
+            ext: zip
+            labels: '["self-hosted","ffmpeg-verify","windows-x86_64"]'
+            via: windows
+    runs-on: ${{ fromJSON(matrix.labels) }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.head-sha }}
+
+      - name: Download RC asset and manifest (unix)
+        if: matrix.via != 'windows'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASSETS: ${{ needs.resolve.outputs.assets }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          PLATFORM: ${{ matrix.platform }}
+          EXT: ${{ matrix.ext }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p rc
+
+          # python3 rather than jq: jq is absent from a stock macOS runner,
+          # python3 is present on every host in this fleet.
+          asset_url() {
+            printf '%s' "$ASSETS" | python3 -c \
+              "import json,sys,os; print(next((a['url'] for a in json.load(sys.stdin) if a['name']==os.environ['N']),''))" N="$1"
+          }
+
+          ARCHIVE=$(printf '%s' "$ASSETS" | python3 -c \
+            "import json,sys,os; print(next((a['name'] for a in json.load(sys.stdin) if os.environ['P'] in a['name'] and a['name'].endswith(os.environ['E'])),''))" \
+            P="$PLATFORM" E="$EXT")
+          [[ -n "$ARCHIVE" ]] || { echo "::error::no ${PLATFORM} archive in ${TAG}"; exit 1; }
+
+          for name in "$ARCHIVE" manifest.json; do
+            url=$(asset_url "$name")
+            [[ -n "$url" ]] || { echo "::error::asset ${name} not in release ${TAG}"; exit 1; }
+            curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+                 -H "Accept: application/octet-stream" "$url" -o "rc/${name}"
+          done
+
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+          ls -lh rc/
+
+      - name: Verify natively
+        if: matrix.via == 'native'
+        shell: bash
+        run: |
+          bash tests/verify-rc.sh \
+            --archive "rc/${ARCHIVE}" \
+            --manifest rc/manifest.json \
+            --platform "${{ matrix.platform }}" \
+            --workdir "${RUNNER_TEMP}/ffmpeg-${{ matrix.platform }}" \
+            --json "verdict-${{ matrix.platform }}.json" \
+            --tag "${{ needs.resolve.outputs.tag }}" \
+            --commit "${{ needs.resolve.outputs.head-sha }}"
+
+      # linux-aarch64 has no dedicated machine — it runs in a native ARM Linux
+      # guest on the Apple Silicon host, which is real aarch64 silicon rather
+      # than emulation.
+      - name: Verify inside the Lima guest
+        if: matrix.via == 'lima'
+        env:
+          LIMA_INSTANCE: ${{ vars.VERIFY_LIMA_INSTANCE }}
+          LIMA_BIN: ${{ vars.VERIFY_LIMA_BIN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "${LIMA_INSTANCE}" ]] || { echo "::error::repo variable VERIFY_LIMA_INSTANCE is not set"; exit 1; }
+          LIMACTL="${LIMA_BIN:-limactl}"
+          REMOTE="/tmp/ffmpeg-verify-${GITHUB_RUN_ID}"
+
+          "$LIMACTL" shell "$LIMA_INSTANCE" -- rm -rf "$REMOTE"
+          "$LIMACTL" shell "$LIMA_INSTANCE" -- mkdir -p "$REMOTE/rc"
+          "$LIMACTL" copy -r tests "${LIMA_INSTANCE}:${REMOTE}/tests"
+          "$LIMACTL" copy "rc/${ARCHIVE}" "${LIMA_INSTANCE}:${REMOTE}/rc/${ARCHIVE}"
+          "$LIMACTL" copy rc/manifest.json "${LIMA_INSTANCE}:${REMOTE}/rc/manifest.json"
+
+          # set +e so a failing suite still lets us retrieve the verdict below;
+          # under set -e the step would abort and the evidence would be lost.
+          set +e
+          "$LIMACTL" shell "$LIMA_INSTANCE" -- bash "${REMOTE}/tests/verify-rc.sh" \
+            --archive "${REMOTE}/rc/${ARCHIVE}" \
+            --manifest "${REMOTE}/rc/manifest.json" \
+            --platform "${{ matrix.platform }}" \
+            --workdir "${REMOTE}/w" \
+            --json "${REMOTE}/verdict.json" \
+            --tag "${{ needs.resolve.outputs.tag }}" \
+            --commit "${{ needs.resolve.outputs.head-sha }}"
+          status=$?
+          set -e
+
+          "$LIMACTL" copy "${LIMA_INSTANCE}:${REMOTE}/verdict.json" "verdict-${{ matrix.platform }}.json"
+          "$LIMACTL" shell "$LIMA_INSTANCE" -- rm -rf "$REMOTE"
+          exit $status
+
+      # FreeBSD has no official Actions runner build, so a Linux runner drives a
+      # real FreeBSD guest over SSH. The suite still executes on FreeBSD.
+      - name: Verify over SSH on the FreeBSD guest
+        if: matrix.via == 'ssh'
+        env:
+          SSH_TARGET: ${{ vars.VERIFY_FREEBSD_SSH_TARGET }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "${SSH_TARGET}" ]] || { echo "::error::repo variable VERIFY_FREEBSD_SSH_TARGET is not set"; exit 1; }
+          SSH_OPTS="-o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10"
+          REMOTE="/tmp/ffmpeg-verify-${GITHUB_RUN_ID}"
+
+          # shellcheck disable=SC2086
+          ssh $SSH_OPTS "$SSH_TARGET" "rm -rf ${REMOTE}; mkdir -p ${REMOTE}/rc"
+          tar -cf - tests | ssh $SSH_OPTS "$SSH_TARGET" "tar -xf - -C ${REMOTE}"
+          scp $SSH_OPTS "rc/${ARCHIVE}" rc/manifest.json "${SSH_TARGET}:${REMOTE}/rc/"
+
+          set +e
+          ssh $SSH_OPTS "$SSH_TARGET" "bash ${REMOTE}/tests/verify-rc.sh \
+            --archive ${REMOTE}/rc/${ARCHIVE} \
+            --manifest ${REMOTE}/rc/manifest.json \
+            --platform ${{ matrix.platform }} \
+            --workdir ${REMOTE}/w \
+            --json ${REMOTE}/verdict.json \
+            --tag ${{ needs.resolve.outputs.tag }} \
+            --commit ${{ needs.resolve.outputs.head-sha }}"
+          status=$?
+          set -e
+
+          scp $SSH_OPTS "${SSH_TARGET}:${REMOTE}/verdict.json" "verdict-${{ matrix.platform }}.json"
+          ssh $SSH_OPTS "$SSH_TARGET" "rm -rf ${REMOTE}" || true
+          exit $status
+
+      - name: Download RC asset and manifest (windows)
+        if: matrix.via == 'windows'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASSETS: ${{ needs.resolve.outputs.assets }}
+          PLATFORM: ${{ matrix.platform }}
+          EXT: ${{ matrix.ext }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Path rc -Force | Out-Null
+          $assets = $env:ASSETS | ConvertFrom-Json
+          $archive = ($assets | Where-Object { $_.name -like "*$($env:PLATFORM)*" -and $_.name.EndsWith($env:EXT) } | Select-Object -First 1)
+          if (-not $archive) { throw "no $($env:PLATFORM) archive in the release" }
+          $manifest = ($assets | Where-Object { $_.name -eq 'manifest.json' } | Select-Object -First 1)
+          $headers = @{ Authorization = "Bearer $($env:GH_TOKEN)"; Accept = 'application/octet-stream' }
+          Invoke-WebRequest -Uri $archive.url -Headers $headers -OutFile "rc/$($archive.name)" -UseBasicParsing
+          Invoke-WebRequest -Uri $manifest.url -Headers $headers -OutFile 'rc/manifest.json' -UseBasicParsing
+          "ARCHIVE=$($archive.name)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Verify natively (windows)
+        if: matrix.via == 'windows'
+        shell: pwsh
+        run: |
+          ./tests/verify-rc.ps1 `
+            -Archive "rc/$env:ARCHIVE" `
+            -Manifest rc/manifest.json `
+            -Platform '${{ matrix.platform }}' `
+            -WorkDir "$env:RUNNER_TEMP\ffmpeg-${{ matrix.platform }}" `
+            -Json "verdict-${{ matrix.platform }}.json" `
+            -Tag '${{ needs.resolve.outputs.tag }}' `
+            -Commit '${{ needs.resolve.outputs.head-sha }}'
+
+      # always() so a failing platform still uploads its verdict — the evidence
+      # comment needs to say WHICH test failed, not just that something did.
+      - name: Upload verdict
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verdict-${{ matrix.platform }}
+          path: verdict-${{ matrix.platform }}.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  # ── Tick the checklist from the verdicts, and only from the verdicts ──────
+  sync-checklist:
+    needs: [resolve, verify]
+    if: always() && needs.resolve.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.head-sha }}
+
+      - name: Download all verdicts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: verdict-*
+          path: verdicts
+          merge-multiple: true
+
+      - name: Sync the PR checklist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ needs.resolve.outputs.pr }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          HEAD_SHA: ${{ needs.resolve.outputs.head-sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node .github/scripts/sync-checklist.js verdicts

--- a/.github/workflows/verify-rc.yml
+++ b/.github/workflows/verify-rc.yml
@@ -56,20 +56,35 @@ jobs:
           EVENT: ${{ github.event_name }}
           RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           RUN_EVENT: ${{ github.event.workflow_run.event }}
+          RUN_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
           INPUT_PR: ${{ inputs.pr }}
         run: |
           set -euo pipefail
 
           if [[ "$EVENT" == "workflow_run" ]]; then
+            # workflow_run executes in the BASE repository, with its secrets and
+            # its token, whatever the triggering run belonged to. The verify job
+            # then checks out a ref and runs the suite from it on the fleet, so
+            # a fork-triggered run would be fork-controlled code on physical
+            # machines here. The RC-matching check further down happens to stop
+            # it today, which is luck rather than a rule. This is the rule.
+            if [[ -n "$RUN_HEAD_REPO" && "$RUN_HEAD_REPO" != "$REPO" ]]; then
+              echo "Build came from ${RUN_HEAD_REPO}, not ${REPO} — refusing to verify a fork on self-hosted hardware."
+              echo "should-run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             if [[ "$RUN_EVENT" != "pull_request" || "$RUN_CONCLUSION" != "success" ]]; then
               echo "Build was ${RUN_CONCLUSION} on a ${RUN_EVENT} event — nothing to verify."
               echo "should-run=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             # PRs into master are only accepted from dev (pr-guards enforces it),
-            # so the open dev->master PR is unambiguous.
+            # so the open dev->master PR is unambiguous. Restricted to PRs whose
+            # head is in THIS repository: --head matches on branch name alone, so
+            # a fork with a branch called dev would otherwise be a candidate.
             PR=$(gh pr list --repo "$REPO" --head dev --base master --state open \
-                   --json number --jq '.[0].number // empty')
+                   --json number,headRepositoryOwner,isCrossRepository \
+                   --jq "[.[] | select(.isCrossRepository == false)][0].number // empty")
           else
             PR="$INPUT_PR"
           fi

--- a/tests/lib/capabilities.ps1
+++ b/tests/lib/capabilities.ps1
@@ -1,0 +1,78 @@
+# Hardware-capability probe shared by tests/tests.ps1 and the automated RC
+# verifier. Mirrors lib/capabilities.sh — same feature names, same answers.
+#
+# Answers "can this host actually exercise it?" without invoking ffmpeg. Asking
+# ffmpeg would make the build its own oracle: a broken encoder would look
+# identical to absent hardware and skip itself green.
+#
+# Hw-Capability returns "available" or "absent:<reason>".
+
+function Get-HwVideoControllers {
+    try { return @(Get-CimInstance Win32_VideoController -ErrorAction Stop) }
+    catch { return @() }
+}
+
+function Test-HwVendorGpu {
+    param([string]$Pattern)
+    $gpus = Get-HwVideoControllers
+    return [bool]($gpus | Where-Object {
+            $_.Name -match $Pattern -or $_.Caption -match $Pattern -or $_.AdapterCompatibility -match $Pattern
+        })
+}
+
+function Hw-CapabilityNvenc {
+    # nvidia-smi is definitive — it only succeeds when the driver is loaded and
+    # a device answers. WMI is the fallback, and it under-reports on headless
+    # and RDP sessions where the adapter does not enumerate.
+    $smi = Get-Command nvidia-smi -ErrorAction SilentlyContinue
+    if ($smi) {
+        $listing = & $smi.Source -L 2>$null
+        if ($LASTEXITCODE -eq 0 -and ($listing -join "`n") -match 'GPU 0:') { return 'available' }
+        return 'absent:nvidia-smi reports no usable GPU'
+    }
+    if (Test-HwVendorGpu 'NVIDIA') { return 'available' }
+    return 'absent:no NVIDIA display adapter reported by Windows'
+}
+
+function Hw-CapabilityAmf {
+    if (-not (Test-HwVendorGpu 'AMD|Radeon')) {
+        return 'absent:no AMD display adapter reported by Windows'
+    }
+    if (-not (Test-Path "$env:SystemRoot\System32\amfrt64.dll")) {
+        return 'absent:AMD GPU present but amfrt64.dll is missing'
+    }
+    return 'available'
+}
+
+function Hw-CapabilityVpl {
+    if (-not (Test-HwVendorGpu 'Intel')) {
+        return 'absent:no Intel display adapter reported by Windows'
+    }
+    $dlls = @(
+        "$env:SystemRoot\System32\libvpl.dll",
+        "$env:SystemRoot\System32\libmfxhw64.dll",
+        "$env:SystemRoot\System32\libvplintel_preview64.dll"
+    )
+    if (-not ($dlls | Where-Object { Test-Path $_ })) {
+        return 'absent:Intel GPU present but no oneVPL/Media SDK runtime is installed'
+    }
+    return 'available'
+}
+
+function Hw-Capability {
+    param([Parameter(Mandatory)][string]$Feature)
+    switch ($Feature) {
+        'nvenc' { return Hw-CapabilityNvenc }
+        'amf' { return Hw-CapabilityAmf }
+        'vpl' { return Hw-CapabilityVpl }
+        'videotoolbox' { return 'absent:VideoToolbox is macOS-only' }
+        default { return "absent:unknown capability '$Feature'" }
+    }
+}
+
+function Hw-CapabilityReason {
+    param([Parameter(Mandatory)][string]$Feature)
+    $answer = Hw-Capability -Feature $Feature
+    if ($answer -eq 'available') { return $null }
+    return ($answer -replace '^absent:', '')
+}

--- a/tests/lib/capabilities.sh
+++ b/tests/lib/capabilities.sh
@@ -33,7 +33,14 @@ _hw_has_pci_display_vendor() {
 		return 1
 		;;
 	FreeBSD)
-		pciconf -lv 2>/dev/null | grep -qi "vendor=${want#0x}" && return 0
+		# pciconf prints `vendor=0x10de` and `class=0x030000`, so the 0x stays on
+		# and the class is filtered the same way the Linux branch filters it.
+		# Stripping the prefix made this pattern unmatchable, which reads as
+		# "no GPU" on a machine that has one - the exact silent skip this file
+		# exists to remove.
+		pciconf -lv 2>/dev/null |
+			grep -B3 -i "vendor=${want}" |
+			grep -qi 'class=0x03' && return 0
 		return 1
 		;;
 	*)

--- a/tests/lib/capabilities.sh
+++ b/tests/lib/capabilities.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Hardware-capability probe shared by tests/tests.sh and the automated RC
+# verifier. Answers one question per feature — "can this host actually exercise
+# it?" — without ever invoking ffmpeg.
+#
+# Asking ffmpeg would make the build its own oracle: a broken encoder would look
+# identical to absent hardware and skip itself green. Every probe here reads the
+# machine instead.
+#
+# Usage:  hw_capability nvenc   ->  prints "available" or "absent:<reason>"
+#
+# Detection is dependency-free on purpose. lspci is absent from minimal
+# containers, and the previous suite treated "lspci missing" as "no GPU", so
+# sysfs is read directly where possible.
+
+HW_VENDOR_NVIDIA="0x10de"
+HW_VENDOR_AMD="0x1002"
+HW_VENDOR_INTEL="0x8086"
+
+# Class 0x03xxxx is "display controller" in the PCI spec.
+_hw_has_pci_display_vendor() {
+	local want="$1"
+	local dev vendor class
+
+	case "$(uname -s)" in
+	Linux)
+		for dev in /sys/bus/pci/devices/*; do
+			[[ -r "${dev}/vendor" && -r "${dev}/class" ]] || continue
+			vendor=$(<"${dev}/vendor")
+			class=$(<"${dev}/class")
+			[[ "${vendor}" == "${want}" && "${class}" == 0x03* ]] && return 0
+		done
+		return 1
+		;;
+	FreeBSD)
+		pciconf -lv 2>/dev/null | grep -qi "vendor=${want#0x}" && return 0
+		return 1
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+# Plain glob expansion rather than compgen -G, so this stays valid on the bash
+# 3.2 that macOS still ships.
+_hw_find_lib() {
+	local pattern="$1"
+	local dir candidate
+	for dir in /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu \
+		/usr/local/lib /opt/amdgpu-pro/lib/x86_64-linux-gnu; do
+		[[ -d "$dir" ]] || continue
+		for candidate in ${dir}/${pattern}; do
+			[[ -e "$candidate" ]] && return 0
+		done
+	done
+	ldconfig -p 2>/dev/null | grep -q "${pattern%%\**}" && return 0
+	return 1
+}
+
+_hw_capability_nvenc() {
+	case "$(uname -s)" in
+	Darwin)
+		echo "absent:macOS has no NVIDIA driver stack"
+		return
+		;;
+	esac
+
+	# nvidia-smi is definitive — it only succeeds when the driver is loaded AND
+	# a device answers. Fall back to the bus when the tool is not installed.
+	if command -v nvidia-smi >/dev/null 2>&1; then
+		if nvidia-smi -L 2>/dev/null | grep -q "^GPU 0:"; then
+			echo "available"
+		else
+			echo "absent:nvidia-smi reports no usable GPU"
+		fi
+		return
+	fi
+
+	if _hw_has_pci_display_vendor "${HW_VENDOR_NVIDIA}"; then
+		if _hw_find_lib "libnvidia-encode.so*"; then
+			echo "available"
+		else
+			echo "absent:NVIDIA GPU present but libnvidia-encode is missing"
+		fi
+		return
+	fi
+
+	echo "absent:no NVIDIA display adapter on the PCI bus"
+}
+
+_hw_capability_amf() {
+	case "$(uname -s)" in
+	Darwin | FreeBSD)
+		echo "absent:AMF is not shipped for $(uname -s)"
+		return
+		;;
+	esac
+
+	if ! _hw_has_pci_display_vendor "${HW_VENDOR_AMD}"; then
+		echo "absent:no AMD display adapter on the PCI bus"
+		return
+	fi
+	if ! _hw_find_lib "libamfrt64.so*"; then
+		echo "absent:AMD GPU present but the AMF runtime is missing"
+		return
+	fi
+	echo "available"
+}
+
+_hw_capability_vpl() {
+	case "$(uname -s)" in
+	Darwin | FreeBSD)
+		echo "absent:oneVPL is not shipped for $(uname -s)"
+		return
+		;;
+	esac
+
+	if ! _hw_has_pci_display_vendor "${HW_VENDOR_INTEL}"; then
+		echo "absent:no Intel display adapter on the PCI bus"
+		return
+	fi
+	if ! _hw_find_lib "libvpl.so*" && ! _hw_find_lib "libmfx.so*"; then
+		echo "absent:Intel GPU present but neither libvpl nor libmfx is installed"
+		return
+	fi
+	echo "available"
+}
+
+_hw_capability_videotoolbox() {
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		echo "available"
+	else
+		echo "absent:VideoToolbox is macOS-only"
+	fi
+}
+
+hw_capability() {
+	case "$1" in
+	nvenc) _hw_capability_nvenc ;;
+	amf) _hw_capability_amf ;;
+	vpl) _hw_capability_vpl ;;
+	videotoolbox) _hw_capability_videotoolbox ;;
+	*)
+		echo "absent:unknown capability '$1'"
+		return 1
+		;;
+	esac
+}
+
+hw_capability_available() {
+	[[ "$(hw_capability "$1")" == "available" ]]
+}
+
+# Succeeds when the feature is usable. Otherwise prints why not and fails, so
+# callers can write `if reason=$(hw_capability_reason nvenc); then`.
+hw_capability_reason() {
+	local answer
+	answer="$(hw_capability "$1")"
+	if [[ "$answer" == "available" ]]; then
+		return 0
+	fi
+	printf '%s' "${answer#absent:}"
+	return 1
+}
+
+# Running this file directly prints the whole capability table — the fleet
+# health check and anyone debugging a runner use it that way.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	for _feature in nvenc amf vpl videotoolbox; do
+		printf '%-14s %s\n' "${_feature}" "$(hw_capability "${_feature}")"
+	done
+fi

--- a/tests/lib/report.ps1
+++ b/tests/lib/report.ps1
@@ -1,0 +1,85 @@
+# Structured result recorder for tests/tests.ps1. Emits the identical schema to
+# lib/report.sh so the checklist bot has one parser, not two.
+#
+# The pretty console output stays as it was for humans. Machines read this JSON
+# instead — scraping the tick and cross glyphs would make the merge gate depend
+# on emoji surviving every terminal, code page and log collector on the way to
+# the bot.
+
+$script:REPORT_PLATFORM = ''
+$script:REPORT_ENTRIES = [System.Collections.Generic.List[object]]::new()
+
+function Report-Init {
+    param([Parameter(Mandatory)][string]$Platform)
+    $script:REPORT_PLATFORM = $Platform
+    $script:REPORT_ENTRIES = [System.Collections.Generic.List[object]]::new()
+}
+
+function Report-Add {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][ValidateSet('passed', 'failed', 'skipped')][string]$Status,
+        [int]$DurationSeconds = 0,
+        [string]$Reason = $null
+    )
+    $script:REPORT_ENTRIES.Add([ordered]@{
+            name       = $Name
+            status     = $Status
+            duration_s = $DurationSeconds
+            reason     = [string]::IsNullOrWhiteSpace($Reason) ? $null : $Reason
+        })
+}
+
+# ffmpeg prints its own version on the first line of -version; read it from the
+# binary under test rather than trusting whatever the caller was told it is.
+function Get-ReportFfmpegVersion {
+    param([string]$Binary)
+    if (-not (Test-Path $Binary)) { return 'unknown' }
+    try {
+        $line = (& $Binary -hide_banner -version 2>$null | Select-Object -First 1)
+        $parts = "$line" -split '\s+'
+        if ($parts.Count -ge 3) { return $parts[2] }
+        return 'unknown'
+    }
+    catch { return 'unknown' }
+}
+
+function Report-Write {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [string]$Binary
+    )
+    $counts = @{ passed = 0; failed = 0; skipped = 0 }
+    foreach ($entry in $script:REPORT_ENTRIES) { $counts[$entry.status]++ }
+
+    $document = [ordered]@{
+        schema         = 1
+        platform       = $script:REPORT_PLATFORM
+        ffmpeg_version = (Get-ReportFfmpegVersion -Binary $Binary)
+        host           = [ordered]@{
+            os       = 'Windows'
+            arch     = $env:PROCESSOR_ARCHITECTURE
+            hostname = [System.Net.Dns]::GetHostName()
+            kernel   = [System.Environment]::OSVersion.Version.ToString()
+        }
+        capabilities   = [ordered]@{
+            nvenc        = (Hw-Capability -Feature 'nvenc')
+            amf          = (Hw-Capability -Feature 'amf')
+            vpl          = (Hw-Capability -Feature 'vpl')
+            videotoolbox = (Hw-Capability -Feature 'videotoolbox')
+        }
+        totals         = [ordered]@{
+            passed  = $counts.passed
+            failed  = $counts.failed
+            skipped = $counts.skipped
+            total   = $script:REPORT_ENTRIES.Count
+        }
+        tests          = @($script:REPORT_ENTRIES)
+    }
+
+    $directory = Split-Path -Parent $Path
+    if ($directory -and -not (Test-Path $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+    $document | ConvertTo-Json -Depth 6 | Set-Content -Path $Path -Encoding utf8
+}

--- a/tests/lib/report.sh
+++ b/tests/lib/report.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Structured result recorder for tests/tests.sh.
+#
+# The pretty console output stays exactly as it was for humans. Machines read
+# this JSON instead — scraping ✅/❌ lines would make the merge gate depend on
+# emoji surviving every terminal, locale and log collector between here and the
+# checklist bot.
+#
+# Usage:
+#   report_init linux-x86_64
+#   report_add libx264 passed 3
+#   report_add AMF skipped 0 "no AMD display adapter on the PCI bus"
+#   report_write /path/to/report.json
+
+REPORT_PLATFORM=""
+REPORT_ENTRIES=()
+
+_json_escape() {
+	local s="$1"
+	s="${s//\\/\\\\}"
+	s="${s//\"/\\\"}"
+	s="${s//$'\t'/\\t}"
+	s="${s//$'\r'/}"
+	s="${s//$'\n'/\\n}"
+	printf '%s' "$s"
+}
+
+report_init() {
+	REPORT_PLATFORM="$1"
+	REPORT_ENTRIES=()
+}
+
+report_add() {
+	local name="$1" status="$2" duration="${3:-0}" reason="${4:-}"
+	local entry
+
+	entry=$(printf '{"name":"%s","status":"%s","duration_s":%s,"reason":' \
+		"$(_json_escape "$name")" "$(_json_escape "$status")" "${duration}")
+	if [[ -z "$reason" ]]; then
+		entry+='null}'
+	else
+		entry+=$(printf '"%s"}' "$(_json_escape "$reason")")
+	fi
+	REPORT_ENTRIES+=("$entry")
+}
+
+_report_count() {
+	local want="$1" n=0 entry
+	for entry in "${REPORT_ENTRIES[@]:-}"; do
+		[[ "$entry" == *"\"status\":\"${want}\""* ]] && n=$((n + 1))
+	done
+	printf '%s' "$n"
+}
+
+# ffmpeg prints its own version on the first line of -version; read it from the
+# binary under test rather than trusting whatever the caller was told it is.
+_report_ffmpeg_version() {
+	local binary="$1"
+	[[ -x "$binary" ]] || {
+		printf 'unknown'
+		return
+	}
+	"$binary" -hide_banner -version 2>/dev/null | head -1 | awk '{print $3}' || printf 'unknown'
+}
+
+report_write() {
+	local path="$1" binary="${2:-}"
+	local tests_json="" entry sep=""
+
+	for entry in "${REPORT_ENTRIES[@]:-}"; do
+		[[ -z "$entry" ]] && continue
+		tests_json+="${sep}${entry}"
+		sep=","
+	done
+
+	mkdir -p "$(dirname "$path")"
+	cat >"$path" <<EOF
+{
+  "schema": 1,
+  "platform": "$(_json_escape "${REPORT_PLATFORM}")",
+  "ffmpeg_version": "$(_json_escape "$(_report_ffmpeg_version "${binary}")")",
+  "host": {
+    "os": "$(_json_escape "$(uname -s)")",
+    "arch": "$(_json_escape "$(uname -m)")",
+    "hostname": "$(_json_escape "$(uname -n)")",
+    "kernel": "$(_json_escape "$(uname -r)")"
+  },
+  "capabilities": {
+    "nvenc": "$(_json_escape "$(hw_capability nvenc)")",
+    "amf": "$(_json_escape "$(hw_capability amf)")",
+    "vpl": "$(_json_escape "$(hw_capability vpl)")",
+    "videotoolbox": "$(_json_escape "$(hw_capability videotoolbox)")"
+  },
+  "totals": {
+    "passed": $(_report_count passed),
+    "failed": $(_report_count failed),
+    "skipped": $(_report_count skipped),
+    "total": ${#REPORT_ENTRIES[@]}
+  },
+  "tests": [${tests_json}]
+}
+EOF
+}

--- a/tests/tests.ps1
+++ b/tests/tests.ps1
@@ -1,6 +1,19 @@
+# Full codec + hardware suite for a nomercy-ffmpeg build.
+#
+# Hardware-accelerated encoders are gated on the host actually having the
+# hardware (see lib/capabilities.ps1). A missing GPU is a skip with a recorded
+# reason, never a failure — and never a silent pass either.
 param (
-    [string]$Workspace = $(throw "Workspace path is required")
+    [string]$Workspace = $(throw "Workspace path is required"),
+    [string]$Platform = 'windows-x86_64',
+    [string]$JsonReport = ''
 )
+
+$HERE = Split-Path -Parent $PSCommandPath
+. "$HERE/lib/capabilities.ps1"
+. "$HERE/lib/report.ps1"
+
+Report-Init -Platform $Platform
 
 $TOTAL_WIDTH_TEXT = 54
 $script:TOTAL_TESTS = 0
@@ -19,21 +32,14 @@ $AssSubPath = $AssSubPath -replace ':','\\:'
 Remove-Item -Recurse -Force -Path $TestRoot -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Path $TestRoot -ErrorAction SilentlyContinue | Out-Null
 
+# Counts the call sites at the bottom of this file so the progress counter can
+# read "[3/26]". Anchored at line start so the definitions above never count.
 function get_test_runs_count {
-    param (
-        [string]$searchString
-    )
-    $filePath = $PSCommandPath
-    $fileContent = Get-Content -Path $filePath -Raw
-    $_matches = [regex]::Matches($fileContent, [regex]::Escape($searchString))
-    $matches_count = $_matches.Count
-    if ( $matches_count -gt 0 ) {
-        $matches_count--
-    }
-    return $matches_count
+    $lines = Get-Content -Path $PSCommandPath
+    return @($lines | Where-Object { $_ -match '^(run_test|run_hw_test) "' }).Count
 }
 
-$TOTAL_RUNS = get_test_runs_count -searchString 'run_test "'
+$TOTAL_RUNS = get_test_runs_count
 
 function generate_samples {
     $Total_Count = 0
@@ -130,43 +136,51 @@ function run_test {
     text_with_padding "🧪 Testing ${name}" "[$script:TOTAL_TESTS/$TOTAL_RUNS]"
     $Start_Time = Get-Date
     $test_output = Invoke-Expression "$Workspace\ffmpeg.exe $command 2>&1" | Out-String
-    if ( $LASTEXITCODE -eq 0 -and $test_output -cmatch $expected_output ) {
-        $End_Time = Get-Date
-        text_with_padding "✅ ${name} test passed" "[ $((New-TimeSpan -Start $Start_Time -End $End_Time).Seconds)s ]" 1
+    $exit_code = $LASTEXITCODE
+    $duration = [int](New-TimeSpan -Start $Start_Time -End (Get-Date)).TotalSeconds
+
+    if ( $exit_code -eq 0 -and $test_output -cmatch $expected_output ) {
+        text_with_padding "✅ ${name} test passed" "[ ${duration}s ]" 1
         $script:PASSED_TESTS++
+        Report-Add -Name $name -Status passed -DurationSeconds $duration
     }
     else {
-        $End_Time = Get-Date
-        text_with_padding "❌ ${name} test failed" "[ $((New-TimeSpan -Start $Start_Time -End $End_Time).Seconds)s ]" 1
+        text_with_padding "❌ ${name} test failed" "[ ${duration}s ]" 1
         $script:FAILED_TESTS++
+        # Print the diagnosis. A red run that swallows its own output costs
+        # another full round trip on whichever machine happens to own it.
+        Write-Host "   exit=${exit_code}, expected to match: ${expected_output}"
+        $tail = ($test_output -split "`r?`n" | Where-Object { $_ } | Select-Object -Last 12)
+        $tail | ForEach-Object { Write-Host "   | $_" }
+        $short = (($test_output -split "`r?`n" | Where-Object { $_ } | Select-Object -Last 3) -join ' ')
+        Report-Add -Name $name -Status failed -DurationSeconds $duration -Reason "exit ${exit_code}; ${short}"
     }
 }
 
-function test_support {
+# Same contract as run_test, but the encoder only runs when the host owns the
+# hardware. Absent hardware skips WITH the reason recorded, so a skip can be
+# audited later instead of being indistinguishable from a pass.
+function run_hw_test {
     param (
-        [ValidateSet("AMF", "VPL")]
-        [string]$Feature
+        $name,
+        $capability,
+        $command,
+        $expected_output
     )
 
-    # Vraag video controllers op (eenmalig, wel zo efficiënt)
-    $gpus = Get-CimInstance Win32_VideoController
-
-    if ($Feature -eq "AMF") {
-        $hasAmdGpu = $gpus | Where-Object { $_.DriverProvider -like "*AMD*" -or $_.Caption -like "*AMD*" -or $_.Caption -like "*Radeon*" }
-        $hasAmfDll = Test-Path "$env:SystemRoot\System32\amfrt64.dll"
-        
-        return [bool]($hasAmdGpu -and $hasAmfDll)
-    }
-    elseif ($Feature -eq "VPL") {
-        $hasIntelGpu = $gpus | Where-Object { $_.DriverProvider -like "*Intel*" -or $_.Caption -like "*Intel*" }
-        $hasVplDll = (Test-Path "$env:SystemRoot\System32\libvplintel_preview64.dll") -or 
-                     (Test-Path "$env:SystemRoot\System32\mfxplugin64.dll") -or 
-                     (Test-Path "$env:SystemRoot\System32\libvpl.dll")
-        
-        return [bool]($hasIntelGpu -and $hasVplDll)
+    $reason = Hw-CapabilityReason -Feature $capability
+    if (-not $reason) {
+        run_test $name $command $expected_output
+        return
     }
 
-    return $false
+    $script:TOTAL_TESTS++
+    $name = $name.ToUpper()
+    text_with_padding "🧪 Testing ${name}" "[$script:TOTAL_TESTS/$TOTAL_RUNS]"
+    text_with_padding "➖ ${name} was skipped" "[ 0s ]" 1
+    Write-Host "   $reason"
+    $script:SKIPPED_TESTS++
+    Report-Add -Name $name -Status skipped -DurationSeconds 0 -Reason $reason
 }
 
 # Main execution
@@ -192,28 +206,11 @@ run_test "libopenjpeg" "-y -i $SampleImage -c:v libopenjpeg $TestRoot\test_jp2.j
 run_test "libass" "-y -i '${SampleVideo}' -vf ass='${AssSubPath}' '${TestRoot}/test_ass.mp4'" "ass"
 run_test "auto_mkdir" "-y -f lavfi -i `"testsrc=duration=1:size=320x240:rate=1`" -frames:v 1 $TestRoot\subdir_test\nested\output.png" "output.png"
 
-# Hardware acceleration (may fail if no hardware support)
-run_test "NVENC" "-y -i $SampleVideo -c:v h264_nvenc $TestRoot\test_nvenc.mp4" "nvenc"
-# Check for Intel GPU/driver otherwise skip
-if (test_support "VPL") {
-    run_test "VPL" "-y -i $SampleVideo -c:v h264_vpl $TestRoot\test_vpl.mp4" "vpl"
-}
-else {
-    $script:TOTAL_TESTS++
-    text_with_padding "🧪 Testing VPL" "[$script:TOTAL_TESTS/$TOTAL_RUNS]"
-    text_with_padding "➖ VPL was skipped" "[ 0s ]" 1
-    $script:SKIPPED_TESTS++
-}
-# Check for AMD GPU/driver otherwise skip
-if (test_support "AMF") {
-    run_test "AMF" "-y -i $SampleVideo -c:v h264_amf $TestRoot\test_amf.mp4" "amf"
-}
-else {
-    $script:TOTAL_TESTS++
-    text_with_padding "🧪 Testing AMF" "[$script:TOTAL_TESTS/$TOTAL_RUNS]"
-    text_with_padding "➖ AMF was skipped" "[ 0s ]" 1
-    $script:SKIPPED_TESTS++
-}
+# Hardware acceleration — each runs only where the hardware exists.
+run_hw_test "NVENC" nvenc "-y -i $SampleVideo -c:v h264_nvenc $TestRoot\test_nvenc.mp4" "nvenc"
+run_hw_test "VPL" vpl "-y -i $SampleVideo -c:v h264_vpl $TestRoot\test_vpl.mp4" "vpl"
+run_hw_test "AMF" amf "-y -i $SampleVideo -c:v h264_amf $TestRoot\test_amf.mp4" "amf"
+run_hw_test "VIDEOTOOLBOX" videotoolbox "-y -i $SampleVideo -c:v h264_videotoolbox $TestRoot\test_vt.mp4" "videotoolbox"
 
 # Additional format tests
 run_test "libbluray" "-hide_banner -protocols | findstr bluray" "bluray"
@@ -239,6 +236,11 @@ text_with_padding "Failed tests:" "$script:FAILED_TESTS"
 text_with_padding "Total tests:" "$script:TOTAL_TESTS"
 Write-Host ([string]::new('-', $TOTAL_WIDTH_TEXT))
 Write-Host ""
+
+if ($JsonReport) {
+    Report-Write -Path $JsonReport -Binary "$Workspace\ffmpeg.exe"
+    Write-Host "📄 Report written to $JsonReport"
+}
 
 Remove-Item -Recurse -Force -Path $TestRoot -ErrorAction SilentlyContinue
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,6 +1,39 @@
 #!/bin/bash
+# Full codec + hardware suite for a nomercy-ffmpeg build.
+#
+# Usage: tests.sh <workspace> [--platform <name>] [--json <report path>]
+#
+# Hardware-accelerated encoders are gated on the host actually having the
+# hardware (see lib/capabilities.sh). A missing GPU is a skip with a recorded
+# reason, never a failure — and never a silent pass either.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/capabilities.sh
+source "${HERE}/lib/capabilities.sh"
+# shellcheck source=lib/report.sh
+source "${HERE}/lib/report.sh"
 
 Workspace="$1"
+shift 2>/dev/null || true
+
+Platform=""
+ReportPath=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--platform)
+		Platform="$2"
+		shift 2
+		;;
+	--json)
+		ReportPath="$2"
+		shift 2
+		;;
+	*)
+		echo "Error: unknown argument '$1'." >&2
+		exit 1
+		;;
+	esac
+done
 
 if [[ -z "$Workspace" ]]; then
 	echo "Error: Workspace path is required." >&2
@@ -11,6 +44,9 @@ if [[ -L "$Workspace" ]]; then
 	echo "Error: Workspace path cannot be a symbolic link." >&2
 	exit 1
 fi
+
+[[ -z "$Platform" ]] && Platform="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
+report_init "$Platform"
 
 TOTAL_WIDTH_TEXT=54
 TOTAL_TESTS=0
@@ -27,22 +63,13 @@ SampleSubs="${TestRoot}/sample.ass"
 rm -rf "${TestRoot}"
 mkdir -p "${TestRoot}"
 
+# Counts the call sites at the bottom of this file so the progress counter can
+# read "[3/25]". Anchored at line start so the definitions above never count.
 get_test_runs_count() {
-	local searchString="$1"
-	local filePath="$0"
-	local fileContent
-	local matches
-	local m_count
-	fileContent=$(<"$filePath")
-	_matches=$(grep -o "$searchString" <<<"$fileContent")
-	matches_count=$(echo "$_matches" | wc -l)
-	if [ "$matches_count" -gt 0 ]; then
-		matches_count=$((matches_count - 1))
-	fi
-	echo "$matches_count"
+	grep -cE '^(run_test|run_hw_test) "' "${BASH_SOURCE[0]}"
 }
 
-TOTAL_RUNS=$(get_test_runs_count 'run_test "')
+TOTAL_RUNS=$(get_test_runs_count)
 
 generate_samples() {
 	local Total_Count=0
@@ -152,6 +179,7 @@ run_test() {
 	local expected_output=$3
 	local test_output
 	local exit_code
+	local duration
 
 	TOTAL_TESTS=$((TOTAL_TESTS + 1))
 	name=$(echo $name | tr '[:lower:]' '[:upper:]')
@@ -161,48 +189,47 @@ run_test() {
 
 	test_output=$(eval "${Workspace}/ffmpeg $command" 2>&1)
 	exit_code=$?
+	End_Time=$(date +%s)
+	duration=$((End_Time - Start_Time))
+
 	if [[ $exit_code -eq 0 ]] && echo "$test_output" | grep -q "$expected_output"; then
-		End_Time=$(date +%s)
-		text_with_padding "✅ ${name} test passed" "[$((End_Time - Start_Time))s]" 1
+		text_with_padding "✅ ${name} test passed" "[${duration}s]" 1
 		PASSED_TESTS=$((PASSED_TESTS + 1))
+		report_add "${name}" passed "${duration}"
 	else
-		End_Time=$(date +%s)
-		text_with_padding "❌ ${name} test failed" "[$((End_Time - Start_Time))s]" 1
+		text_with_padding "❌ ${name} test failed" "[${duration}s]" 1
 		FAILED_TESTS=$((FAILED_TESTS + 1))
+		# Print the diagnosis. A red run that swallows its own output costs
+		# another full round trip on whichever machine happens to own it.
+		echo "   exit=${exit_code}, expected to match: ${expected_output}"
+		echo "$test_output" | tail -12 | sed 's/^/   | /'
+		report_add "${name}" failed "${duration}" \
+			"exit ${exit_code}; $(echo "$test_output" | tail -3 | tr '\n' ' ')"
 	fi
 }
 
-test_support() {
-	local feature=$1
+# Same contract as run_test, but the encoder only runs when the host owns the
+# hardware. Absent hardware skips WITH the reason recorded, so a skip can be
+# audited later instead of being indistinguishable from a pass.
+run_hw_test() {
+	local name=$1
+	local capability=$2
+	local command=$3
+	local expected_output=$4
+	local reason
 
-	# Haal GPU informatie op via lspci
-	local gpu_info
-	gpu_info=$(lspci 2>/dev/null | grep -E "VGA|Display|3D")
-
-	if [ "$feature" = "AMF" ]; then
-		# Check of het een AMD GPU is en of de AMF library bestaat (vaak meegeleverd met AMDVLK/Pro drivers)
-		echo "$gpu_info" | grep -iq "AMD"
-		local has_amd=$?
-
-		# Check veelvoorkomende locaties voor de AMF library op Linux
-		if [ $has_amd -eq 0 ] && [ -f "/usr/lib/x86_64-linux-gnu/libamfrt64.so" ] || [ -f "/usr/lib64/libamfrt64.so" ] || [ -f "/opt/amdgpu-pro/lib/x86_64-linux-gnu/libamfrt64.so" ]; then
-			return 0 # True / Ondersteund
-		fi
-		return 1 # False
-
-	elif [ "$feature" = "VPL" ]; then
-		# Check of het een Intel GPU is
-		echo "$gpu_info" | grep -iq "Intel"
-		local has_intel=$?
-
-		# Check voor oneVPL / Media SDK bibliotheken (libvpl of libmfx)
-		if [ $has_intel -eq 0 ] && ldconfig -p 2>/dev/null | grep -E -q "libvpl\.so|libmfx\.so"; then
-			return 0 # True / Ondersteund
-		fi
-		return 1 # False
+	if reason=$(hw_capability_reason "$capability"); then
+		run_test "$name" "$command" "$expected_output"
+		return
 	fi
 
-	return 1
+	TOTAL_TESTS=$((TOTAL_TESTS + 1))
+	name=$(echo $name | tr '[:lower:]' '[:upper:]')
+	text_with_padding "🧪 Testing ${name}" "[${TOTAL_TESTS}/${TOTAL_RUNS}]" 1
+	text_with_padding "➖ ${name} was skipped" "[0s]" 1
+	echo "   ${reason}"
+	SKIPPED_TESTS=$((SKIPPED_TESTS + 1))
+	report_add "${name}" skipped 0 "${reason}"
 }
 
 # Main execution
@@ -238,27 +265,11 @@ run_test "libopenjpeg" "-y -i ${SampleImage} -c:v libopenjpeg ${TestRoot}/test_j
 run_test "libass" "-y -i ${SampleVideo} -vf \"ass=${SampleSubs}\" ${TestRoot}/test_ass.mp4" "ass"
 run_test "auto_mkdir" "-y -f lavfi -i \"testsrc=duration=1:size=320x240:rate=1\" -frames:v 1 ${TestRoot}/subdir_test/nested/output.png" "output.png"
 
-# Hardware acceleration (may fail if no hardware support)
-run_test "NVENC" "-y -i ${SampleVideo} -c:v h264_nvenc ${TestRoot}/test_nvenc.mp4" "nvenc"
-# Check for Intel GPU/driver otherwise skip
-if test_support "VPL"; then
-	run_test "VPL" "-y -i ${SampleVideo} -c:v h264_vpl ${TestRoot}/test_vpl.mp4" "vpl"
-else
-	TOTAL_TESTS=$((TOTAL_TESTS + 1))
-	text_with_padding "🧪 Testing VPL" "[$script:TOTAL_TESTS/$TOTAL_RUNS]"
-	text_with_padding "➖ VPL was skipped" "[ 0s ]" 1
-	SKIPPED_TESTS=$((SKIPPED_TESTS + 1))
-fi
-
-# Check for AMD GPU/driver otherwise skip
-if test_support "AMF"; then
-	run_test "AMF" "-y -i ${SampleVideo} -c:v h264_amf ${TestRoot}/test_amf.mp4" "amf"
-else
-	TOTAL_TESTS=$((TOTAL_TESTS + 1))
-	text_with_padding "🧪 Testing AMF" "[$script:TOTAL_TESTS/$TOTAL_RUNS]"
-	text_with_padding "➖ AMF was skipped" "[ 0s ]" 1
-	SKIPPED_TESTS=$((SKIPPED_TESTS + 1))
-fi
+# Hardware acceleration — each runs only where the hardware exists.
+run_hw_test "NVENC" nvenc "-y -i ${SampleVideo} -c:v h264_nvenc ${TestRoot}/test_nvenc.mp4" "nvenc"
+run_hw_test "VPL" vpl "-y -i ${SampleVideo} -c:v h264_vpl ${TestRoot}/test_vpl.mp4" "vpl"
+run_hw_test "AMF" amf "-y -i ${SampleVideo} -c:v h264_amf ${TestRoot}/test_amf.mp4" "amf"
+run_hw_test "VIDEOTOOLBOX" videotoolbox "-y -i ${SampleVideo} -c:v h264_videotoolbox ${TestRoot}/test_vt.mp4" "videotoolbox"
 
 # Additional format tests
 run_test "libbluray" "-hide_banner -protocols | grep bluray" "bluray"
@@ -284,6 +295,11 @@ text_with_padding "Failed tests:" "${FAILED_TESTS}"
 text_with_padding "Total tests:" "${TOTAL_TESTS}"
 printf "%${TOTAL_WIDTH_TEXT}s\n" | tr ' ' '-' # Print a horizontal line
 echo ""
+
+if [[ -n "$ReportPath" ]]; then
+	report_write "$ReportPath" "${Workspace}/ffmpeg"
+	echo "📄 Report written to ${ReportPath}"
+fi
 
 rm -rf "${TestRoot}"
 

--- a/tests/verify-rc.ps1
+++ b/tests/verify-rc.ps1
@@ -11,8 +11,11 @@ param(
     [Parameter(Mandatory)][string]$Platform,
     [Parameter(Mandatory)][string]$WorkDir,
     [Parameter(Mandatory)][string]$Json,
-    [string]$Commit = '',
-    [string]$Tag = ''
+    # Mandatory, not optional. These two are the only thing tying a verdict to
+    # the build it came from, and a verdict that cannot name its commit and
+    # release proves nothing about which bytes were tested.
+    [Parameter(Mandatory)][string]$Commit,
+    [Parameter(Mandatory)][string]$Tag
 )
 
 $ErrorActionPreference = 'Stop'

--- a/tests/verify-rc.ps1
+++ b/tests/verify-rc.ps1
@@ -1,0 +1,125 @@
+# Verifies one Release Candidate archive on the machine that can actually run
+# it, and writes a verdict the checklist bot can act on. Windows counterpart of
+# verify-rc.sh — same arguments, same verdict schema.
+#
+# The integrity check is not decoration. The bot ticks a merge-blocking box
+# based on this file, so the verdict has to say which bytes were tested — a
+# report that cannot name its own artifact's digest proves nothing.
+param(
+    [Parameter(Mandatory)][string]$Archive,
+    [string]$Manifest = '',
+    [Parameter(Mandatory)][string]$Platform,
+    [Parameter(Mandatory)][string]$WorkDir,
+    [Parameter(Mandatory)][string]$Json,
+    [string]$Commit = '',
+    [string]$Tag = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$HERE = Split-Path -Parent $PSCommandPath
+
+function Write-FailVerdict {
+    param([string]$Stage, [string]$Detail)
+    $document = [ordered]@{
+        schema        = 1
+        platform      = $Platform
+        tag           = $Tag
+        commit        = $Commit
+        verdict       = 'fail'
+        failed_stage  = $Stage
+        detail        = $Detail
+        integrity     = [ordered]@{ verified = $false }
+        report        = $null
+    }
+    $directory = Split-Path -Parent $Json
+    if ($directory -and -not (Test-Path $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+    $document | ConvertTo-Json -Depth 6 | Set-Content -Path $Json -Encoding utf8
+    Write-Host "❌ ${Stage}: ${Detail}"
+    exit 1
+}
+
+Write-Host "─── Verifying $(Split-Path -Leaf $Archive) for ${Platform} ───"
+
+if (-not (Test-Path $Archive)) { Write-FailVerdict 'download' "archive not found: $Archive" }
+
+$assetName = Split-Path -Leaf $Archive
+$actualSha = (Get-FileHash -Path $Archive -Algorithm SHA256).Hash.ToLower()
+
+# The manifest is the release's own record of what was published. Checking the
+# archive against it catches a truncated download and a swapped asset alike.
+$expectedSha = ''
+if ($Manifest -and (Test-Path $Manifest)) {
+    $manifestDocument = Get-Content -Raw -Path $Manifest | ConvertFrom-Json
+    $entry = $manifestDocument.assets | Where-Object { $_.name -eq $assetName }
+    if (-not $entry) { Write-FailVerdict 'integrity' "manifest.json has no entry for $assetName" }
+    $expectedSha = "$($entry.sha256)".ToLower()
+    if ($expectedSha -ne $actualSha) {
+        Write-FailVerdict 'integrity' "sha256 mismatch — manifest $expectedSha, downloaded $actualSha"
+    }
+    Write-Host "✅ sha256 matches manifest: $actualSha"
+}
+else {
+    Write-Host '::warning::no manifest supplied — recording the digest without cross-checking it'
+}
+
+if (Test-Path $WorkDir) { Remove-Item -Recurse -Force $WorkDir }
+New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
+
+try {
+    if ($assetName -like '*.zip') { Expand-Archive -Path $Archive -DestinationPath $WorkDir -Force }
+    elseif ($assetName -like '*.tar.gz') { tar -xzf $Archive -C $WorkDir }
+    else { Write-FailVerdict 'extract' "unsupported archive type: $assetName" }
+}
+catch { Write-FailVerdict 'extract' $_.Exception.Message }
+
+if (-not (Test-Path "$WorkDir\ffmpeg.exe")) {
+    Write-FailVerdict 'extract' "no ffmpeg.exe inside $assetName"
+}
+
+# A build for another OS or CPU can load and then die in ways that look like a
+# codec failure. Refuse to report on a binary this host cannot execute at all.
+& "$WorkDir\ffmpeg.exe" -hide_banner -version *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-FailVerdict 'exec' "the $Platform binary does not execute on this host"
+}
+
+$reportPath = Join-Path $WorkDir 'report.json'
+& "$HERE\tests.ps1" -Workspace $WorkDir -Platform $Platform -JsonReport $reportPath
+$suiteExit = $LASTEXITCODE
+
+if (-not (Test-Path $reportPath)) {
+    Write-FailVerdict 'suite' "tests.ps1 produced no report (exit $suiteExit)"
+}
+
+$document = [ordered]@{
+    schema     = 1
+    platform   = $Platform
+    tag        = $Tag
+    commit     = $Commit
+    verdict    = ($suiteExit -eq 0) ? 'pass' : 'fail'
+    suite_exit = $suiteExit
+    integrity  = [ordered]@{
+        verified = [bool]$expectedSha
+        asset    = $assetName
+        sha256   = $actualSha
+    }
+    # Windows targets always run natively here; the field exists so the bot has
+    # one shape to read across every platform.
+    execution  = [ordered]@{
+        native      = $true
+        translation = $null
+        host_arch   = $env:PROCESSOR_ARCHITECTURE
+    }
+    report     = (Get-Content -Raw -Path $reportPath | ConvertFrom-Json)
+}
+
+$directory = Split-Path -Parent $Json
+if ($directory -and -not (Test-Path $directory)) {
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+}
+$document | ConvertTo-Json -Depth 8 | Set-Content -Path $Json -Encoding utf8
+
+Write-Host "📄 Verdict ($($document.verdict)) written to $Json"
+exit $suiteExit

--- a/tests/verify-rc.sh
+++ b/tests/verify-rc.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Verifies one Release Candidate archive on the machine that can actually run
+# it, and writes a verdict the checklist bot can act on.
+#
+# Usage:
+#   verify-rc.sh --archive <file> --manifest <manifest.json> --platform <name> \
+#                --workdir <dir> --json <verdict.json> [--commit <sha>] [--tag <tag>]
+#
+# The integrity check is not decoration. The bot ticks a merge-blocking box
+# based on this file, so the verdict has to say which bytes were tested — a
+# report that cannot name its own artifact's digest proves nothing.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+Archive=""
+Manifest=""
+Platform=""
+WorkDir=""
+JsonOut=""
+Commit=""
+Tag=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--archive)
+		Archive="$2"
+		shift 2
+		;;
+	--manifest)
+		Manifest="$2"
+		shift 2
+		;;
+	--platform)
+		Platform="$2"
+		shift 2
+		;;
+	--workdir)
+		WorkDir="$2"
+		shift 2
+		;;
+	--json)
+		JsonOut="$2"
+		shift 2
+		;;
+	--commit)
+		Commit="$2"
+		shift 2
+		;;
+	--tag)
+		Tag="$2"
+		shift 2
+		;;
+	*)
+		echo "Error: unknown argument '$1'." >&2
+		exit 2
+		;;
+	esac
+done
+
+# Spelled out rather than looped over ${!name} + ${name,,} — macOS still ships
+# bash 3.2, where lowercase expansion is a syntax error.
+[[ -n "$Archive" ]] || { echo "Error: --archive is required." >&2; exit 2; }
+[[ -n "$Platform" ]] || { echo "Error: --platform is required." >&2; exit 2; }
+[[ -n "$WorkDir" ]] || { echo "Error: --workdir is required." >&2; exit 2; }
+[[ -n "$JsonOut" ]] || { echo "Error: --json is required." >&2; exit 2; }
+
+# sha256 has a different tool name on every platform this fleet covers.
+sha256_of() {
+	local file="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$file" | awk '{print $1}'
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$file" | awk '{print $1}'
+	elif command -v sha256 >/dev/null 2>&1; then
+		sha256 -q "$file"
+	else
+		echo "Error: no sha256 tool found on this host." >&2
+		return 1
+	fi
+}
+
+fail_verdict() {
+	local stage="$1" detail="$2"
+	mkdir -p "$(dirname "$JsonOut")"
+	cat >"$JsonOut" <<EOF
+{
+  "schema": 1,
+  "platform": "${Platform}",
+  "tag": "${Tag}",
+  "commit": "${Commit}",
+  "verdict": "fail",
+  "failed_stage": "${stage}",
+  "detail": "${detail//\"/\'}",
+  "integrity": { "verified": false },
+  "report": null
+}
+EOF
+	echo "❌ ${stage}: ${detail}" >&2
+	exit 1
+}
+
+echo "─── Verifying $(basename "$Archive") for ${Platform} ───"
+
+[[ -f "$Archive" ]] || fail_verdict download "archive not found: ${Archive}"
+
+AssetName="$(basename "$Archive")"
+ActualSha="$(sha256_of "$Archive")" || fail_verdict integrity "no sha256 tool available"
+
+# The manifest is the release's own record of what was published. Checking the
+# archive against it catches a truncated download and a swapped asset alike.
+ExpectedSha=""
+if [[ -n "$Manifest" && -f "$Manifest" ]]; then
+	ExpectedSha=$(
+		tr -d '\n\t ' <"$Manifest" |
+			grep -o "\"name\":\"${AssetName}\",\"sha256\":\"[0-9a-f]*\"" |
+			grep -o '[0-9a-f]\{64\}' | head -1
+	)
+	[[ -n "$ExpectedSha" ]] || fail_verdict integrity "manifest.json has no entry for ${AssetName}"
+	[[ "$ExpectedSha" == "$ActualSha" ]] ||
+		fail_verdict integrity "sha256 mismatch — manifest ${ExpectedSha}, downloaded ${ActualSha}"
+	echo "✅ sha256 matches manifest: ${ActualSha}"
+else
+	echo "::warning::no manifest supplied — recording the digest without cross-checking it"
+fi
+
+rm -rf "$WorkDir"
+mkdir -p "$WorkDir"
+case "$AssetName" in
+*.tar.gz) tar -xzf "$Archive" -C "$WorkDir" || fail_verdict extract "tar failed" ;;
+*.zip) unzip -oq "$Archive" -d "$WorkDir" || fail_verdict extract "unzip failed" ;;
+*) fail_verdict extract "unsupported archive type: ${AssetName}" ;;
+esac
+
+[[ -f "${WorkDir}/ffmpeg" ]] || fail_verdict extract "no ffmpeg binary inside ${AssetName}"
+chmod +x "${WorkDir}/ffmpeg" "${WorkDir}/ffprobe" 2>/dev/null || true
+
+# A build for another OS or CPU can load and then die in ways that look like a
+# codec failure. Refuse to report on a binary this host cannot execute at all.
+if ! "${WorkDir}/ffmpeg" -hide_banner -version >/dev/null 2>&1; then
+	fail_verdict exec "the ${Platform} binary does not execute on $(uname -s)/$(uname -m)"
+fi
+
+# Record whether the binary ran natively. darwin-x86_64 on an Apple Silicon Mac
+# is a Rosetta 2 translation, and "tested on real hardware" has to say so —
+# otherwise the evidence reads as an x86 Mac nobody owns.
+TargetArch="${Platform##*-}"
+HostArch="$(uname -m)"
+case "$HostArch" in
+amd64) HostArch="x86_64" ;;
+aarch64) HostArch="arm64" ;;
+esac
+case "$TargetArch" in
+aarch64) TargetArch="arm64" ;;
+esac
+
+Native="true"
+Translation="null"
+if [[ "$TargetArch" != "$HostArch" ]]; then
+	Native="false"
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		Translation='"rosetta2"'
+	else
+		Translation='"unknown"'
+	fi
+	echo "ℹ️  ${Platform} is running translated on ${HostArch}"
+fi
+
+ReportPath="${WorkDir}/report.json"
+bash "${HERE}/tests.sh" "$WorkDir" --platform "$Platform" --json "$ReportPath"
+SuiteExit=$?
+
+[[ -f "$ReportPath" ]] || fail_verdict suite "tests.sh produced no report (exit ${SuiteExit})"
+
+Verdict="fail"
+[[ "$SuiteExit" -eq 0 ]] && Verdict="pass"
+
+mkdir -p "$(dirname "$JsonOut")"
+{
+	printf '{\n'
+	printf '  "schema": 1,\n'
+	printf '  "platform": "%s",\n' "$Platform"
+	printf '  "tag": "%s",\n' "$Tag"
+	printf '  "commit": "%s",\n' "$Commit"
+	printf '  "verdict": "%s",\n' "$Verdict"
+	printf '  "suite_exit": %s,\n' "$SuiteExit"
+	printf '  "integrity": {\n'
+	printf '    "verified": %s,\n' "$([[ -n "$ExpectedSha" ]] && echo true || echo false)"
+	printf '    "asset": "%s",\n' "$AssetName"
+	printf '    "sha256": "%s"\n' "$ActualSha"
+	printf '  },\n'
+	printf '  "execution": {\n'
+	printf '    "native": %s,\n' "$Native"
+	printf '    "translation": %s,\n' "$Translation"
+	printf '    "host_arch": "%s"\n' "$HostArch"
+	printf '  },\n'
+	printf '  "report": '
+	cat "$ReportPath"
+	printf '\n}\n'
+} >"$JsonOut"
+
+echo "📄 Verdict (${Verdict}) written to ${JsonOut}"
+exit "$SuiteExit"

--- a/tests/verify-rc.sh
+++ b/tests/verify-rc.sh
@@ -64,6 +64,11 @@ done
 [[ -n "$Platform" ]] || { echo "Error: --platform is required." >&2; exit 2; }
 [[ -n "$WorkDir" ]] || { echo "Error: --workdir is required." >&2; exit 2; }
 [[ -n "$JsonOut" ]] || { echo "Error: --json is required." >&2; exit 2; }
+# Required, not optional. These two are the only thing tying a verdict to the
+# build it came from, and a verdict that cannot name its commit and release
+# proves nothing about which bytes were tested.
+[[ -n "$Commit" ]] || { echo "Error: --commit is required." >&2; exit 2; }
+[[ -n "$Tag" ]] || { echo "Error: --tag is required." >&2; exit 2; }
 
 # sha256 has a different tool name on every platform this fleet covers.
 sha256_of() {


### PR DESCRIPTION
## Why

Every RC needs six platforms tested on real hardware before the checklist can be
ticked and `master` unblocked. That is a lot of manual work per release, repeated
on every push to the PR. This proposes doing it on a fleet of real machines.

Two things need saying up front, because they change what a tick currently means.

**`tests.sh` and `tests.ps1` cannot pass on four of the six platforms today.**
`run_test "NVENC"` is called unconditionally while AMF and VPL are guarded by
`test_support`, so the suite hard-fails on every host without an NVIDIA GPU —
all macOS, FreeBSD, aarch64 and GPU-less Linux targets. Reproduced against
`v1.0.39-rc` `linux-x86_64` in a GPU-less container:

```
✅ 22 passed   ➖ 2 skipped   ❌ 1 failed (NVENC)   exit 1
```

**`test_support` has an operator-precedence bug.** `[ $has_amd -eq 0 ] && [ -f A ] || [ -f B ] || [ -f C ]`
is true on a non-AMD host whenever B or C exists, so AMF could be attempted on
hardware that cannot run it. Detection also went through `lspci`, which is absent
from minimal containers and was silently read as "no GPU".

So the first commit fixes the harness; the second builds the automation on top.
Automating the tick on top of the current script would have industrialised a
signal that does not hold.

## What changed

**`fix(tests)`** — every accelerator is gated the same way and records *why* it
skipped, so a skip can be audited instead of being indistinguishable from a pass.
PCI detection reads sysfs directly. VideoToolbox is covered on macOS. Failing
tests print their output instead of swallowing it. `--json` writes a structured
report; console output is unchanged for humans.

**`feat(ci)`** — `verify-rc.yml` runs one job per checklist platform on its own
machine, and `sync-checklist.js` ticks boxes from the resulting verdicts.

The rule the bot enforces: **a tick must be evidence.** A box is ticked only from
a verdict file proving *this* commit's artifact was tested on hardware that could
run it. Job success is never sufficient. The artifact digest must match
`manifest.json`, and the verdict's commit and tag must match the PR head, so a
stale run cannot tick for a newer push. Anything unproven stays unticked and the
merge stays blocked — the same outcome as nobody testing it.

`verify-rc.sh` also refuses to report on a binary the host cannot execute. A
FreeBSD build loads on Linux and *then* segfaults, which would otherwise look
like a codec failure rather than a wrong runner.

## The fleet

| Checklist item | Machine | Execution |
|---|---|---|
| `linux-x86_64` | Proxmox LXC | native |
| `linux-aarch64` | Mac mini, Lima guest | native ARM64 (not emulated) |
| `windows-x86_64` | Desktop w/ RTX 2080 SUPER | native |
| `darwin-arm64` | Mac mini M4 | native |
| `darwin-x86_64` | Mac mini M4 | Rosetta 2, recorded as translated |
| `freebsd-x86_64` | Proxmox VM, FreeBSD 14.3 | native, driven over SSH |

FreeBSD is pinned to 14.3 to match `FREEBSD_VERSION` in
`ffmpeg-freebsd-x86_64.dockerfile`. A different major version is a different ABI,
so a pass there would not mean the shipped binary works.

## Verified, not just written

Every row below is a real run against the live `v1.0.39-rc` assets, digest-checked
against `manifest.json`:

| Platform | Result | Notes |
|---|---|---|
| `linux-x86_64` | 22 passed, 4 skipped, 0 failed | |
| `linux-aarch64` | 22 passed, 4 skipped, 0 failed | native ARM64 |
| `darwin-arm64` | 23 passed, 3 skipped, 0 failed | includes a real VideoToolbox encode |
| `darwin-x86_64` | 23 passed, 3 skipped, 0 failed | under Rosetta 2 |
| `freebsd-x86_64` | 22 passed, 4 skipped, 0 failed | |
| `windows-x86_64` | 23 passed, 3 skipped, 0 failed | includes a real NVENC encode at 3.03x |

Negative cases were checked too: a tampered archive is refused on digest
mismatch, and the FreeBSD and aarch64 binaries are both refused on a Linux
x86_64 host rather than being reported as codec failures.

`sync-checklist.js` has unit tests covering every refusal path — wrong commit,
wrong tag, unverified digest, empty results, and a `pass` verdict carrying failed
totals.

## Limits, stated plainly

**AMF and VPL are never positively verified.** There is no AMD GPU and no Intel
iGPU anywhere in the fleet. The suite skips them with a recorded reason and the
bot reports them as untested rather than folding them into a green tick. Adding
an AMD or Intel card to the Proxmox host is the only thing that changes this.

**Linux NVENC is unverified.** The only NVIDIA card is in a Windows desktop, and
NVENC cannot be reached through WSL2 or a container — `cuInit` succeeds and the
encode then dies with SIGFPE. Windows NVENC is verified natively instead.

The hardware checklist line is therefore satisfied by acceleration genuinely
exercised somewhere in the fleet, with the untestable paths named in the comment
rather than hidden.

## What this does not do

It does not merge anything. It ticks the boxes and posts the evidence, and the
merge stays a human decision.

## Needs

Three repository variables, already set:

| Variable | Value |
|---|---|
| `VERIFY_LIMA_INSTANCE` | `linux-arm64` |
| `VERIFY_LIMA_BIN` | `/Users/stoney/lima/bin/limactl` |
| `VERIFY_FREEBSD_SSH_TARGET` | `root@192.168.2.245` |

Fleet provisioning lives in `infra/nomercy-ci/ffmpeg-verify` (scripts + README),
outside this repo.
