### PR TITLE
Keep fork pull requests off the self-hosted machines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,9 +32,19 @@ jobs:
       force_rebuild: ${{ inputs.force_rebuild || github.event_name == 'pull_request' }}
 
   # ── Base image (every platform FROMs this) ───────────────────────────────
+  # This repository is public and this workflow runs on pull_request, so the
+  # three jobs below would otherwise be reachable from a fork. GitHub withholds
+  # secrets from fork PRs, but not the runner: an approved fork PR executes its
+  # own code on our hardware. The approval gate is a setting someone can relax
+  # or misclick, so the jobs that touch self-hosted machines say so themselves.
+  # Everything else is unchanged - push, workflow_dispatch and same-repo PRs,
+  # which is what the RC flow uses.
   build-base:
     needs: detect-changes
-    if: needs.detect-changes.outputs.base-changed == 'true'
+    if: |
+      needs.detect-changes.outputs.base-changed == 'true'
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/reusable-docker-build.yml
     with:
       dockerfile: ffmpeg-base.dockerfile
@@ -57,6 +67,8 @@ jobs:
       always() && !cancelled()
       && needs.detect-changes.outputs.platforms-to-build != '[]'
       && (needs.build-base.result == 'success' || needs.build-base.result == 'skipped')
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +102,8 @@ jobs:
     if: |
       always() && !cancelled()
       && needs.build-platforms.result == 'success'
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, beast-unit]
     steps:
       - name: Log in to DockerHub


### PR DESCRIPTION
Came out of thinking about lending runner capacity between our two fleets. Before any of that, this one is worth closing.

This repository is public and `main.yml` runs on `pull_request`. Three of its jobs land on self-hosted hardware:

| Job | Runs on |
|---|---|
| `build-base` | `labels: beast-unit` |
| `build-platforms` | `labels: beast-unit` |
| `export-artifacts` | `[self-hosted, beast-unit]` |

**Secrets are not the problem.** GitHub withholds repository secrets from `pull_request` runs originating in a fork, so `DOCKER_PASSWORD` and `PAT_TOKEN` stay empty. That protection holds and I confirmed it is the documented behaviour rather than assuming it.

**The runner is the problem.** GitHub does not withhold that. An approved fork PR executes its own workflow code on beast-unit, alongside the Docker daemon those jobs use. The only thing in front of it is the fork-PR approval setting under Settings, Actions, General, which defaults to requiring approval for first-time contributors. That means a returning contributor does not need approving, and the setting itself is a checkbox that can be relaxed or misclicked once.

So the three jobs now state the condition themselves rather than depending on a setting being remembered:

```yaml
&& (github.event_name != 'pull_request'
    || github.event.pull_request.head.repo.full_name == github.repository)
```

`push`, `workflow_dispatch` and same-repo pull requests are unaffected, which is everything the RC flow uses. Validated by parsing the workflow and asserting the guard is present on exactly those three jobs, with the other six untouched.

Worth a look at the same pattern elsewhere: `nomercy-media-server` is also public and has workflows on self-hosted labels. I have not touched that one.

While you are in that settings page, two org-wide defaults are worth a glance for the same reason: `default_workflow_permissions` is currently `write`, and `can_approve_pull_request_reviews` is on. Neither is exploitable through a fork PR, since that token is downgraded to read-only regardless, but both are wider than they need to be for everything else.