### PR TITLE
Stop non-release pull requests from claiming the RC tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,14 +199,33 @@ jobs:
         shell: pwsh
         run: ./tests/smoke.ps1 -Workspace $env:GITHUB_WORKSPACE -ExpectedVersion $env:FFMPEG_VERSION
 
-  # ── Publish/refresh the Release Candidate prerelease (PR only) ───────────
+  # ── Publish/refresh the Release Candidate prerelease (release PR only) ───
   # Gives contributors version-stamped binaries to test manually on each
   # platform. Deleted+recreated each run so assets and tag always match the
-  # latest PR head. Promoted to a real release on master merge (see release).
+  # latest release-PR head. Promoted to a real release on master merge (see
+  # release).
+  #
+  # Restricted to the dev->master PR. This job deletes and recreates one shared
+  # tag, so without a branch condition the RC belongs to whichever PR into
+  # master finished last. That is not theoretical: a workflow-only PR branched
+  # from master republished v1.0.39-rc over the one dev had published, and for
+  # fourteen hours the advertised release candidate contained none of the
+  # twenty commits it was supposed to be shipping. Nothing caught it, because
+  # the manual suite proves libraries were compiled in rather than that the new
+  # features work, so it passed on the wrong binaries. pr-guards already says
+  # PRs into master come from dev; this says it where the damage happens.
+  #
+  # head_ref is a bare branch name, so the same-repo check is not redundant: a
+  # fork's branch called `dev` satisfies the first condition. It cannot reach
+  # this job today only because export-artifacts is fork-guarded, and inheriting
+  # a guarantee from another job's condition is the kind of coincidence that
+  # stops being true the moment that job is refactored.
   publish-rc:
     needs: [detect-changes, export-artifacts, smoke-test]
     if: |
       github.event_name == 'pull_request'
+      && github.head_ref == 'dev'
+      && github.event.pull_request.head.repo.full_name == github.repository
       && needs.export-artifacts.result == 'success'
       && needs.smoke-test.result == 'success'
     runs-on: ubuntu-latest
@@ -327,12 +346,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify the PR build path is green
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           base='${{ needs.build-base.result }}'
           platforms='${{ needs.build-platforms.result }}'
           export='${{ needs.export-artifacts.result }}'
           smoke='${{ needs.smoke-test.result }}'
           echo "base=$base platforms=$platforms export=$export smoke=$smoke"
+
+          # A fork PR skips the three self-hosted jobs by design, so every check
+          # below would report 'skipped' and read as a broken build. Say what
+          # actually happened instead. This still fails: the PR genuinely was
+          # not built, and a green required check on an unbuilt PR would be a
+          # worse lie than a confusing red one.
+          if [[ -n "$HEAD_REPO" && "$HEAD_REPO" != "${GITHUB_REPOSITORY}" ]]; then
+            echo "❌ Not built: pull requests from forks are not run on this"
+            echo "   repository's self-hosted hardware (head repo: ${HEAD_REPO})."
+            echo "   A maintainer has to push the branch to ${GITHUB_REPOSITORY}"
+            echo "   to get a build."
+            exit 1
+          fi
+
           # On a PR we force a full build, so build-base must succeed.
           if [[ "$base" != "success" ]]; then echo "❌ build-base: $base"; exit 1; fi
           if [[ "$platforms" != "success" ]]; then echo "❌ build-platforms: $platforms"; exit 1; fi


### PR DESCRIPTION
Closes #44.

`publish-rc` deletes and recreates one shared `${version}-rc` tag on every pull request into `master`. With more than one PR open, the release candidate belongs to whichever run finished last.

That happened. PR #43 — a workflow-only change branched from `master` — republished `v1.0.39-rc` over the one `dev` had published thirteen hours earlier:

| | |
|---|---|
| Published from `dev` (#39) | 2026-07-27 17:34, run `30289817322` |
| Overwritten by #43 | 2026-07-28 06:25, run `30327382754` |
| `target_commitish` after | `e9a09cdf` — #43's head |
| `manifest.json` `commit_sha` | `4f9193c8` = `refs/pull/43/merge` |
| Release body read | `Built from PR #43 (branch fix/no-fork-prs-on-self-hosted)` |

`refs/pull/43/merge` is `master` plus one workflow file. For fourteen hours the advertised release candidate contained none of the twenty commits on `dev` — no `dvdread://`, no HLS master-playlist work, no whisper language detection, no keydetect, no spritevtt fix, no HEVC alpha.

**Nothing would have caught it.** `tests.sh` proves a library was compiled in, not that a feature works:

```sh
run_test "libdvdread" "-hide_banner -version | grep dvdread" "dvdread"
```

`--enable-libdvdread` is in the `master` build too. A tester would have downloaded the RC, run the suite on real hardware, seen 22 passed / 4 skipped, and ticked their platform box in complete good faith on a binary missing the entire release. Six platforms, six green ticks.

## What changed

`publish-rc` is restricted to the `dev`->`master` pull request. Any other PR into `master` still builds and smoke-tests exactly as now; it just cannot touch the RC tag.

The same-repo condition is **not** redundant with `head_ref`. `head_ref` is a bare branch name, so a fork branch called `dev` satisfies it. Today that is stopped only by `export-artifacts` being fork-guarded — inheriting a guarantee from another job's condition, which is the same coincidence-rather-than-a-rule pattern #43 was written to remove.

`pr-build` also now reports a fork PR honestly. Its dependencies are skipped by design there, so every check read `skipped` and looked like a broken build. It still fails — the PR genuinely was not built, and a green required check on an unbuilt PR is a worse lie than a confusing red one — but it says why.

## Checked

YAML parses. The `pr-build` branch was exercised on all four paths:

| Case | Result |
|---|---|
| Fork PR, everything skipped | fails with the fork message |
| Same-repo PR, all green | passes |
| Same-repo PR, real build failure | fails with `build-platforms: failure`, not the fork message |
| `HEAD_REPO` unset (non-PR) | unaffected |

The third is the one that matters — a genuine failure still names its real cause.

## Not in scope

Two things from #44 left open deliberately:

- `GPG_SIGNING_KEY` is not set, so `manifest.json.sig` has never been produced despite the release body advertising it. Needs a decision, not a workflow edit.
- The suite's `-version | grep <lib>` tests prove build flags rather than behaviour. That is what made this invisible, and fixing it properly means a real per-feature test — worth its own change.