### PR TITLE
x265: verify the multilib merge instead of assuming it took

### DIFF
--- a/ffmpeg-darwin-arm64.dockerfile
+++ b/ffmpeg-darwin-arm64.dockerfile
@@ -215,7 +215,7 @@ RUN FFMPEG_ENABLES=$(cat /build/enable.txt) export FFMPEG_ENABLES \
     --extra-cflags="-arch ${ARCH} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
     --extra-ldflags="-arch ${ARCH} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" \
     --extra-libs="${FFMPEG_EXTRA_LIBFLAGS}" >/ffmpeg_build.log 2>&1 \
-    || (cat "/ffmpeg_build.log" ; echo "❌ FFmpeg build failed" ; false) \
+    || (cat "/ffmpeg_build.log" ; cat "/build/ffmpeg/ffbuild/config.log" 2>/dev/null ; echo "❌ FFmpeg build failed" ; false) \
     && echo "🛠️ Building FFmpeg                               [2/2]" \
     && make -j$(nproc) >/ffmpeg_build.log 2>&1 || (cat "/ffmpeg_build.log" ; echo "❌ FFmpeg build failed" ; exit 1) && make install >/dev/null 2>&1 \
     && rm -rf /build/ffmpeg \

--- a/ffmpeg-freebsd-x86_64.dockerfile
+++ b/ffmpeg-freebsd-x86_64.dockerfile
@@ -193,7 +193,7 @@ RUN FFMPEG_ENABLES=$(cat /build/enable.txt) export FFMPEG_ENABLES \
     --extra-cflags="-static" \
     --extra-ldflags="-static" \
     --extra-libs="${FFMPEG_EXTRA_LIBFLAGS}" >/ffmpeg_build.log 2>&1 \
-    || (cat "/ffmpeg_build.log" ; echo "❌ FFmpeg build failed" ; false) \
+    || (cat "/ffmpeg_build.log" ; cat "/build/ffmpeg/ffbuild/config.log" 2>/dev/null ; echo "❌ FFmpeg build failed" ; false) \
     && echo "🛠️ Building FFmpeg                               [2/2]" \
     && make -j$(nproc) >/ffmpeg_build.log 2>&1 || (cat "/ffmpeg_build.log" ; cat "/build/ffmpeg/ffbuild/config.log" ; echo "❌ FFmpeg build failed" ; exit 1) && make install >/dev/null 2>&1 \
     && rm -rf /build/ffmpeg \

--- a/ffmpeg-linux-aarch64.dockerfile
+++ b/ffmpeg-linux-aarch64.dockerfile
@@ -158,7 +158,7 @@ RUN FFMPEG_ENABLES=$(cat /build/enable.txt) export FFMPEG_ENABLES \
     --extra-cflags="-static -static-libgcc -static-libstdc++" \
     --extra-ldflags="-static -static-libgcc -static-libstdc++" \
     --extra-libs="${FFMPEG_EXTRA_LIBFLAGS}" >/ffmpeg_build.log 2>&1 \
-    || (cat "/ffmpeg_build.log" ; echo "❌ FFmpeg build failed" ; false) \
+    || (cat "/ffmpeg_build.log" ; cat "/build/ffmpeg/ffbuild/config.log" 2>/dev/null ; echo "❌ FFmpeg build failed" ; false) \
     && echo "🛠️ Building FFmpeg                               [2/2]" \
     && make -j$(nproc) >/ffmpeg_build.log 2>&1 || (cat "/ffmpeg_build.log" ; echo "❌ FFmpeg build failed" ; exit 1) && make install >/dev/null 2>&1 \
     && rm -rf /build/ffmpeg \

--- a/ffmpeg-linux-x86_64.dockerfile
+++ b/ffmpeg-linux-x86_64.dockerfile
@@ -145,7 +145,7 @@ RUN FFMPEG_ENABLES=$(cat /build/enable.txt) export FFMPEG_ENABLES \
     --extra-cflags="-static -static-libgcc -static-libstdc++" \
     --extra-ldflags="-static -static-libgcc -static-libstdc++" \
     --extra-libs="${FFMPEG_EXTRA_LIBFLAGS}" >/ffmpeg_build.log 2>&1 \
-    || (cat "/ffmpeg_build.log" ; echo "❌ FFmpeg build failed" ; false) \
+    || (cat "/ffmpeg_build.log" ; cat "/build/ffmpeg/ffbuild/config.log" 2>/dev/null ; echo "❌ FFmpeg build failed" ; false) \
     && echo "🛠️ Building FFmpeg                               [2/2]" \
     && make -j$(nproc) >/ffmpeg_build.log 2>&1 || (cat "/ffmpeg_build.log" ; cat "/build/ffmpeg/ffbuild/config.log" ; echo "❌ FFmpeg build failed" ; exit 1) && make install >/dev/null 2>&1 \
     && rm -rf /build/ffmpeg \

--- a/ffmpeg-windows-arm64.dockerfile
+++ b/ffmpeg-windows-arm64.dockerfile
@@ -180,7 +180,7 @@ RUN FFMPEG_ENABLES=$(cat /build/enable.txt) export FFMPEG_ENABLES \
     --extra-cflags="-static -static-libgcc -static-libstdc++" \
     --extra-ldflags="-static -static-libgcc -static-libstdc++" \
     --extra-libs="${FFMPEG_EXTRA_LIBFLAGS}" >/ffmpeg_build.log 2>&1 \
-    || (cat "/ffmpeg_build.log" ; echo "❌ FFmpeg build failed" ; false) \
+    || (cat "/ffmpeg_build.log" ; cat "/build/ffmpeg/ffbuild/config.log" 2>/dev/null ; echo "❌ FFmpeg build failed" ; false) \
     && echo "🛠️ Building FFmpeg                               [2/2]" \
     && make -j$(nproc) >/ffmpeg_build.log 2>&1 || (cat "/ffmpeg_build.log" ; echo "❌ FFmpeg build failed" ; exit 1) && make install >/dev/null 2>&1 \
     && rm -rf /build/ffmpeg \

--- a/ffmpeg-windows-x86_64.dockerfile
+++ b/ffmpeg-windows-x86_64.dockerfile
@@ -161,7 +161,7 @@ RUN FFMPEG_ENABLES=$(cat /build/enable.txt) export FFMPEG_ENABLES \
     --extra-cflags="-static -static-libgcc -static-libstdc++" \
     --extra-ldflags="-static -static-libgcc -static-libstdc++" \
     --extra-libs="${FFMPEG_EXTRA_LIBFLAGS}" >/ffmpeg_build.log 2>&1 \
-    || (cat "/ffmpeg_build.log" ; echo "❌ FFmpeg build failed" ; false) \
+    || (cat "/ffmpeg_build.log" ; cat "/build/ffmpeg/ffbuild/config.log" 2>/dev/null ; echo "❌ FFmpeg build failed" ; false) \
     && echo "🛠️ Building FFmpeg                               [2/2]" \
     && make -j$(nproc) >/ffmpeg_build.log 2>&1 || (cat "/ffmpeg_build.log" ; echo "❌ FFmpeg build failed" ; exit 1) && make install >/dev/null 2>&1 \
     && rm -rf /build/ffmpeg \

--- a/scripts/32-x265.sh
+++ b/scripts/32-x265.sh
@@ -42,6 +42,14 @@ make -j$(nproc)
 
 # install x265
 mv libx265.a libx265_main.a
+
+# Member count of the 8-bit-only archive, to prove the merge below actually
+# added the other two. Existence proves nothing: an unmerged libx265.a is a
+# perfectly good archive that simply lacks x265_10bit:: and x265_12bit::, and
+# the first thing that notices is ffmpeg's configure, 25 minutes later, saying
+# "x265 not found using pkg-config" — which sends you looking at pkg-config.
+main_members=$(${AR} t libx265_main.a 2>/dev/null | wc -l)
+
 if [[ "${TARGET_OS}" == "darwin" ]]; then
     ${CROSS_PREFIX}libtool -static -o libx265.a libx265_main.a libx265_main10.a libx265_main12.a
     ${RANLIB} libx265.a
@@ -61,11 +69,39 @@ else
     fi
 fi
 
+merged_members=$(${AR} t libx265.a 2>/dev/null | wc -l)
+if [ "${merged_members}" -le "${main_members}" ]; then
+    {
+        echo "Error: the x265 multilib merge did not take."
+        echo "libx265_main.a has ${main_members} members, merged libx265.a has ${merged_members}."
+        echo "A merged archive must contain all three, or ffmpeg fails much later"
+        echo "with 'undefined symbol: x265_10bit::x265_api_get_*'."
+    } >/ffmpeg_build.log
+    exit 1
+fi
+
 make install
+
+# Put the merged archive in place AFTER install. `make install` depends on the
+# `all` target, so it can relink libx265.a from the 8-bit objects and overwrite
+# the merge that just happened — whether it does comes down to timestamps,
+# which is why this fails intermittently rather than every time.
+cp -f libx265.a ${PREFIX}/lib/libx265.a
+${RANLIB} ${PREFIX}/lib/libx265.a 2>/dev/null || true
+
 rm -rf /build/x265
 
 if [ ! -f ${PREFIX}/lib/libx265.a ]; then
     echo "Error: libx265.a is missing from lib" >/ffmpeg_build.log
+    exit 1
+fi
+
+installed_members=$(${AR} t ${PREFIX}/lib/libx265.a 2>/dev/null | wc -l)
+if [ "${installed_members}" -ne "${merged_members}" ]; then
+    {
+        echo "Error: the installed libx265.a is not the merged one."
+        echo "Merged archive has ${merged_members} members, installed has ${installed_members}."
+    } >/ffmpeg_build.log
     exit 1
 fi
 


### PR DESCRIPTION
`freebsd-x86_64` failed on the RC rebuild (run `30399011649`), which is what #39 is waiting for. Both retry attempts failed, so it is not transient.

## What it looks like

25 minutes into ffmpeg's configure:

```
ld.lld: error: undefined symbol: x265_10bit::x265_api_get_215(int)
ld.lld: error: undefined symbol: x265_12bit::x265_api_get_215(int)
ld.lld: error: undefined symbol: x265_10bit::x265_api_query(int, int, int*)
ld.lld: error: undefined symbol: x265_12bit::x265_api_query(int, int, int*)
ERROR: x265 not found using pkg-config
```

The last line is the one that gets read, and it sends you to pkg-config. pkg-config is fine.

## What actually happened

25 minutes earlier, in the same job:

```
✅ X265 was built successfully                 [ 08m ]
```

`scripts/32-x265.sh` builds 8/10/12-bit separately and merges the three archives, then checks its work with `[ ! -f libx265.a ]`. An unmerged `libx265.a` is a perfectly good archive that simply lacks `x265_10bit::` and `x265_12bit::`, so existence cannot distinguish the two. The step reported success and the failure surfaced far downstream wearing someone else's name.

## Two changes

**The merge is verified.** A merged archive must contain more members than the 8-bit archive it was built from, and the installed archive must match the merged one. Both refusals name the actual problem:

```
Error: the x265 multilib merge did not take.
libx265_main.a has 84 members, merged libx265.a has 84.
A merged archive must contain all three, or ffmpeg fails much later
with 'undefined symbol: x265_10bit::x265_api_get_*'.
```

**The merged archive is placed after `make install`.** `make install` depends on the `all` target, so it can relink `libx265.a` from the 8-bit objects and overwrite the merge that just happened. Whether it does comes down to timestamps — which is the best explanation I have for why this built fine on runs `30289817322` and `30327382754` and failed on this one, with the same script and x265 pinned to `Release_4.1`.

## Verification

I cannot run a FreeBSD cross-build locally, so CI is the real proof. What I could check is the guard logic, against real `ar` archives on a Linux toolchain:

```
a real MRI merge:
  merged archive                   main=2 merged=4 -> pass OK

the failure the build actually hit - merge silently not applied:
  8-bit archive passed off as merged main=2 merged=2 -> fail OK

Old check for comparison:
  [ -f libx265.a ] -> passes (cannot tell them apart)
  [ -f libx265_unmerged.a ] -> passes (cannot tell them apart)
```

## Note

The change touches all platforms, not just FreeBSD, because the weakness is in the shared script rather than the FreeBSD branch of it. The darwin path uses `libtool -static` instead of an MRI script and is not suspected, but it gets the same verification — if its merge ever fails, it should fail there and not in ffmpeg's configure.

Worth your eye on the `cp -f` after `make install`: if there is a reason install must be the thing that places the archive, say so and I will invert it to install-then-merge instead.