### PR TITLE
fix(deps): point Dependabot at dev so its PRs can actually merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+
+# Dependabot opens its PRs against the repository's default branch unless told
+# otherwise. That branch is master, and pr-guards.yml's guard-source-branch
+# rejects any PR into master whose head is not `dev`:
+#
+#   ❌ PRs into master are only allowed from 'dev' (got 'dependabot/...').
+#
+# So every Dependabot PR failed the moment it opened and could never be merged
+# -- PR #47 (postcss) sat open for days for exactly this reason, and each new
+# one would have joined it. target-branch puts them on dev instead, where they
+# go to master the same way everything else does: through the dev -> master
+# release PR.
+updates:
+  # The npm client published as @nomercy-entertainment/ffmpeg-static.
+  # This is the only JS package in the repo; the FFmpeg build itself pins its
+  # dependency versions in ffmpeg-base.dockerfile, which Dependabot does not
+  # read, so those are still bumped by hand (see UPDATE.md).
+  - package-ecosystem: npm
+    directory: /clients/npm
+    target-branch: dev
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Keep the security-driven bumps together, matching how the postcss and
+      # nanoid updates already arrive as one PR.
+      npm_and_yarn:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)

--- a/clients/npm/package-lock.json
+++ b/clients/npm/package-lock.json
@@ -4556,9 +4556,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.15",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-			"integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -4809,9 +4809,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+			"version": "8.5.25",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+			"integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
 			"dev": true,
 			"funding": [
 				{
@@ -4829,7 +4829,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},


### PR DESCRIPTION
Dependabot had no config, so it opened against the default branch, `master`. `pr-guards.yml`'s `guard-source-branch` rejects any PR into `master` whose head is not `dev`:

```
❌ PRs into master are only allowed from 'dev' (got 'dependabot/...').
```

So every Dependabot PR failed the moment it opened. #47 sat open from 2 August with `guard-source-branch`, `pr-validation`, `checklist-complete`, `build-base` and `pr-build` all red, and each future one would have joined it — while the "1 high vulnerability" banner kept appearing on every push with no mergeable way to clear it.

`target-branch: dev` puts them where work actually starts, so they reach `master` the same way everything else does: through the `dev → master` release PR, with the guard satisfied.

## Also included

#47's lockfile bump, taken directly since that PR cannot merge:

- `postcss` 8.5.16 → 8.5.25
- `nanoid` 3.3.15 → 3.3.16

Both are transitive **devDependencies** (via vitest/eslint), and the advisory's own scope is `development`. The published package ships only `README.md` and `dist/`, so nothing consumers install was ever affected. The advisory (PostCSS path traversal via source-map auto-loading) needs postcss to process attacker-controlled CSS; this repo has none.

Verified with `npm ci` (exit 0) and the client test suite (5 passed, 1 skipped).

## Scope

Only the npm client is configured. The FFmpeg build pins its dependency versions in `ffmpeg-base.dockerfile`, which Dependabot does not read — those stay manual, as UPDATE.md describes. Adding the `github-actions` or `docker` ecosystems would open new PR streams and is deliberately left out.

Note the GitHub alert will not clear until this reaches `master`, since alerts are scanned on the default branch.

Closes #47